### PR TITLE
add Equal tolerance method to Quaternion

### DIFF
--- a/include/ignition/math/Quaternion.hh
+++ b/include/ignition/math/Quaternion.hh
@@ -689,15 +689,25 @@ namespace ignition
         return _v + uv + uuv;
       }
 
+      /// \brief Equality test with tolerance.
+      /// \param[in] _qt Quaternion<T> for comparison
+      /// \param[in] _tol equality tolerance
+      /// \return true if the elements of the quaternions are equal
+      /// within the tolerance specified by _tol, false otherwise
+      public: bool Equal(const Quaternion<T> &_qt, const T &_tol) const
+      {
+        return equal(this->qx, _qt.qx, _tol) &&
+               equal(this->qy, _qt.qy, _tol) &&
+               equal(this->qz, _qt.qz, _tol) &&
+               equal(this->qw, _qt.qw, _tol);
+      }
+
       /// \brief Equal to operator
       /// \param[in] _qt Quaternion<T> for comparison
       /// \return True if equal
       public: bool operator==(const Quaternion<T> &_qt) const
       {
-        return equal(this->qx, _qt.qx, static_cast<T>(0.001)) &&
-               equal(this->qy, _qt.qy, static_cast<T>(0.001)) &&
-               equal(this->qz, _qt.qz, static_cast<T>(0.001)) &&
-               equal(this->qw, _qt.qw, static_cast<T>(0.001));
+        return this->Equal(_qt, static_cast<T>(0.001));
       }
 
       /// \brief Not equal to operator
@@ -705,10 +715,7 @@ namespace ignition
       /// \return True if not equal
       public: bool operator!=(const Quaternion<T> &_qt) const
       {
-        return !equal(this->qx, _qt.qx, static_cast<T>(0.001)) ||
-               !equal(this->qy, _qt.qy, static_cast<T>(0.001)) ||
-               !equal(this->qz, _qt.qz, static_cast<T>(0.001)) ||
-               !equal(this->qw, _qt.qw, static_cast<T>(0.001));
+        return !(*this == _qt);
       }
 
       /// \brief Unary minus operator

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -132,6 +132,28 @@ TEST(QuaternionTest, ConstructAxisAngle)
 }
 
 /////////////////////////////////////////////////
+TEST(QuaternionTest, Equal)
+{
+  // doubles
+  math::Quaterniond q(1, 2, 3, 4);
+  math::Quaterniond q2(1.01, 2.015, 3.002, 4.007);
+  EXPECT_TRUE(q.Equal(q2, 0.02));
+  EXPECT_FALSE(q.Equal(q2, 0.01));
+
+  // floats
+  math::Quaternionf q3(1, 2, 3, 4);
+  math::Quaternionf q4(1.05f, 2.1f, 3.03f, 4.04f);
+  EXPECT_TRUE(q3.Equal(q4, 0.2f));
+  EXPECT_FALSE(q3.Equal(q4, 0.04f));
+
+  // ints
+  math::Quaternioni q5(3, 5, -1, 9);
+  math::Quaternioni q6(3, 6, 1, 12);
+  EXPECT_TRUE(q5.Equal(q6, 3));
+  EXPECT_FALSE(q5.Equal(q6, 2));
+}
+
+/////////////////////////////////////////////////
 TEST(QuaternionTest, Identity)
 {
   math::Quaterniond q = math::Quaterniond::Identity;


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🎉 New feature

## Summary
I've added a method to compare equality between quaternions with a user-defined tolerance, similar to the [Vector3 class](https://github.com/ignitionrobotics/ign-math/blob/e5f264b92cf56e121ab58ef38bf216a1413c6708/include/ignition/math/Vector3.hh#L554-L564). This is useful in cases where the default precision of the quaternion's `==` operator (.001) isn't enough, such as in https://github.com/ignitionrobotics/ign-physics/pull/223 (since physics requires high precision, 1e-6 is used for equality tolerance instead of 1e-3).

## Test it

Take a look at the unit tests written in this PR (files changed tab -> `src/Quaternion_TEST.cc`).

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**