### PR TITLE
Fix clang warnings.

### DIFF
--- a/src/Inertial_TEST.cc
+++ b/src/Inertial_TEST.cc
@@ -231,7 +231,7 @@ void SetRotation(const double _mass,
     math::Quaterniond(-0.1, 0.2, -0.3),
     math::Quaterniond(0.4, 0.2, 0.5),
     math::Quaterniond(-0.1, 0.7, -0.7)};
-  for (const auto rot : rotations)
+  for (const auto &rot : rotations)
   {
     {
       auto inertial = inertialRef;

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -29,7 +29,7 @@ static const std::map<MaterialType, Material> kMaterials = []()
 {
   std::map<MaterialType, Material> matMap;
 
-  for (const std::pair<MaterialType, MaterialData> &mat : kMaterialData)
+  for (const std::pair<const MaterialType, MaterialData> &mat : kMaterialData)
   {
     matMap[mat.first].SetType(mat.first);
     matMap[mat.first].SetName(mat.second.name);
@@ -79,7 +79,7 @@ Material::Material(const std::string &_typename)
   std::string material = _typename;
   std::transform(material.begin(), material.end(), material.begin(), ::tolower);
 
-  for (const std::pair<MaterialType, Material> &mat : kMaterials)
+  for (const std::pair<const MaterialType, Material> &mat : kMaterials)
   {
     if (mat.second.Name() == material)
     {
@@ -198,7 +198,7 @@ void Material::SetToNearestDensity(const double _value, const double _epsilon)
   double min = MAX_D;
   Material result;
 
-  for (const std::pair<MaterialType, Material> &mat : kMaterials)
+  for (const std::pair<const MaterialType, Material> &mat : kMaterials)
   {
     double diff = std::fabs(mat.second.Density() - _value);
     if (diff < min && diff < _epsilon)


### PR DESCRIPTION
When building Material.cc with clang, it warns that the loop
construct used is a reference, but a copy is going to be made
anyway because of a const/non-const mismatch.  Fix this by
adding const to the loop variable type, which removes the
warning and should be more efficient.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

Fixes warnings that come when building ign-math6 with clang.  See https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/940/clang/new/ for the warnings themselves.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests (no new tests needed, compilation warning only)
- [x] Updated documentation (as needed) (not needed)
- [x] Updated migration guide (as needed) (not needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**