### PR TITLE
MassMatrix3: fix bug in PrincipalAxesOffset tolerances

### DIFF
--- a/include/ignition/math/MassMatrix3.hh
+++ b/include/ignition/math/MassMatrix3.hh
@@ -711,9 +711,9 @@ namespace ignition
       /// with MOI = R(q).Transpose() * L * R(q)
       public: Quaternion<T> PrincipalAxesOffset(const T _tol = 1e-6) const
       {
+        Vector3<T> moments = this->PrincipalMoments(_tol);
         // Compute tolerance relative to maximum value of inertia diagonal
         T tol = _tol * this->Ixxyyzz.Max();
-        Vector3<T> moments = this->PrincipalMoments(tol);
         if (moments.Equal(this->Ixxyyzz, tol) ||
             (math::equal<T>(moments[0], moments[1], std::abs(tol)) &&
              math::equal<T>(moments[0], moments[2], std::abs(tol))))

--- a/src/MassMatrix3_TEST.cc
+++ b/src/MassMatrix3_TEST.cc
@@ -776,7 +776,8 @@ TEST(MassMatrix3dTest, EquivalentBox)
     EXPECT_EQ(m, m2);
   }
 
-  // box 1x4x9 rotated by 90 degrees around Z
+  // box 9x4x1 rotated by 90 degrees around Z
+  // equivalent to 4x9x1 after rotation
   {
     const double mass = 12.0;
     const math::Vector3d ixxyyzz(82, 17, 97);
@@ -786,13 +787,15 @@ TEST(MassMatrix3dTest, EquivalentBox)
     EXPECT_TRUE(m.EquivalentBox(size, rot, -1e-6));
     EXPECT_EQ(size, math::Vector3d(9, 4, 1));
     EXPECT_EQ(rot, math::Quaterniond(0, 0, IGN_PI/2));
+    // equivalent to 4x9x1 after rotation
+    EXPECT_EQ((rot * size).Abs(), math::Vector3d(4, 9, 1));
 
     math::MassMatrix3d m2;
     EXPECT_TRUE(m2.SetFromBox(mass, size, rot));
     EXPECT_EQ(m, m2);
   }
 
-  // box 1x4x9 rotated by 45 degrees around Z
+  // box 9x4x1 rotated by 45 degrees around Z
   {
     const double mass = 12.0;
     const math::Vector3d ixxyyzz(49.5, 49.5, 97);

--- a/src/MassMatrix3_TEST.cc
+++ b/src/MassMatrix3_TEST.cc
@@ -293,8 +293,12 @@ TEST(MassMatrix3dTest, PrincipalMoments)
     EXPECT_EQ(m.PrincipalMoments(), Ieigen);
     EXPECT_TRUE(m.IsPositive());
     EXPECT_FALSE(m.IsValid());
-    // Test with different tolerances
+    // Ratio between largest diagonal and non-diagonal elements is 0.5
+    // With relative tolerance of 0.49, the matrix is clearly non-diagonal,
+    // so expect PrincipalMoments to return the sorted eigenvectors.
     EXPECT_EQ(m.PrincipalMoments(0.49), Ieigen);
+    // With relative tolerance of 0.51, the matrix appears to be diagonal,
+    // so expect PrincipalMoments to return the diagonal elements.
     EXPECT_EQ(m.PrincipalMoments(0.51), Ixxyyzz);
   }
 
@@ -308,8 +312,12 @@ TEST(MassMatrix3dTest, PrincipalMoments)
     EXPECT_EQ(m.PrincipalMoments(), Ieigen);
     EXPECT_TRUE(m.IsPositive());
     EXPECT_TRUE(m.IsValid());
-    // Test with different tolerances
+    // Ratio between largest diagonal and non-diagonal elements is 0.25
+    // With relative tolerance of 0.24, the matrix is clearly non-diagonal,
+    // so expect PrincipalMoments to return the sorted eigenvectors.
     EXPECT_EQ(m.PrincipalMoments(0.24), Ieigen);
+    // With relative tolerance of 0.26, the matrix appears to be diagonal,
+    // so expect PrincipalMoments to return the diagonal elements.
     EXPECT_EQ(m.PrincipalMoments(0.26), Ixxyyzz);
   }
 
@@ -351,10 +359,13 @@ TEST(MassMatrix3dTest, PrincipalMoments)
     // the accuracy is approximately 2e-2
     EXPECT_TRUE(m.PrincipalMoments().Equal(Ieigen, 2.5e-2));
     EXPECT_FALSE(m.PrincipalMoments().Equal(Ieigen, 1.5e-2));
-    // test PrincipalMoments relative tolerance
-    EXPECT_EQ(m.PrincipalMoments(11e-6), Ixxyyzz);
-    EXPECT_TRUE(m.PrincipalMoments(9e-6).Equal(Ieigen, 2.5e-2));
-    EXPECT_FALSE(m.PrincipalMoments(9e-6).Equal(Ieigen, 1.5e-2));
+    // Ratio between largest diagonal and non-diagonal elements is 1e5
+    // With relative tolerance of 1.1e5, the matrix appears to be diagonal,
+    // so expect PrincipalMoments to return the diagonal elements.
+    EXPECT_EQ(m.PrincipalMoments(1.1e-5), Ixxyyzz);
+    // With relative tolerance of 0.9e5, the matrix is clearly non-diagonal,
+    // so expect PrincipalMoments to return the sorted eigenvectors.
+    EXPECT_TRUE(m.PrincipalMoments(0.9e-5).Equal(Ieigen, 2.5e-2));
     // the default tolerance for == is 1e-6
     // so this should resolve as not equal
     EXPECT_NE(m.PrincipalMoments(), Ieigen);

--- a/src/MassMatrix3_TEST.cc
+++ b/src/MassMatrix3_TEST.cc
@@ -293,6 +293,9 @@ TEST(MassMatrix3dTest, PrincipalMoments)
     EXPECT_EQ(m.PrincipalMoments(), Ieigen);
     EXPECT_TRUE(m.IsPositive());
     EXPECT_FALSE(m.IsValid());
+    // Test with different tolerances
+    EXPECT_EQ(m.PrincipalMoments(0.49), Ieigen);
+    EXPECT_EQ(m.PrincipalMoments(0.51), Ixxyyzz);
   }
 
   // Non-trivial off-diagonal product moments
@@ -305,6 +308,9 @@ TEST(MassMatrix3dTest, PrincipalMoments)
     EXPECT_EQ(m.PrincipalMoments(), Ieigen);
     EXPECT_TRUE(m.IsPositive());
     EXPECT_TRUE(m.IsValid());
+    // Test with different tolerances
+    EXPECT_EQ(m.PrincipalMoments(0.24), Ieigen);
+    EXPECT_EQ(m.PrincipalMoments(0.26), Ixxyyzz);
   }
 
   // Degenerate matrix with eigenvalue of 0
@@ -345,6 +351,10 @@ TEST(MassMatrix3dTest, PrincipalMoments)
     // the accuracy is approximately 2e-2
     EXPECT_TRUE(m.PrincipalMoments().Equal(Ieigen, 2.5e-2));
     EXPECT_FALSE(m.PrincipalMoments().Equal(Ieigen, 1.5e-2));
+    // test PrincipalMoments relative tolerance
+    EXPECT_EQ(m.PrincipalMoments(11e-6), Ixxyyzz);
+    EXPECT_TRUE(m.PrincipalMoments(9e-6).Equal(Ieigen, 2.5e-2));
+    EXPECT_FALSE(m.PrincipalMoments(9e-6).Equal(Ieigen, 1.5e-2));
     // the default tolerance for == is 1e-6
     // so this should resolve as not equal
     EXPECT_NE(m.PrincipalMoments(), Ieigen);
@@ -365,6 +375,17 @@ TEST(MassMatrix3dTest, PrincipalAxesOffsetIdentity)
   EXPECT_TRUE(m.SetOffDiagonalMoments(math::Vector3d::Zero));
   EXPECT_TRUE(m.IsValid());
   EXPECT_EQ(m.PrincipalAxesOffset(), math::Quaterniond::Identity);
+
+  // Non-diagonal matrices may have identity axes offset depending on the
+  // tolerance.
+  m.SetDiagonalMoments(10 * math::Vector3d::One);
+  m.SetOffDiagonalMoments(math::Vector3d::One);
+  EXPECT_TRUE(m.IsValid());
+  // relative tolerance is large enough that it looks like a diagonal matrix
+  // so expect identity
+  EXPECT_EQ(m.PrincipalAxesOffset(0.11), math::Quaterniond::Identity);
+  // relative tolerance is small enough that it should not return identity
+  EXPECT_NE(m.PrincipalAxesOffset(0.09), math::Quaterniond::Identity);
 }
 
 /////////////////////////////////////////////////
@@ -573,6 +594,9 @@ TEST(MassMatrix3dTest, PrincipalAxesOffsetNoRepeat)
   // Non-diagonal inertia matrix with f1 = 0
   VerifyNondiagonalMomentsAndAxes(math::Vector3d(3, 4, 6),
     math::Vector3d(3.0, 5.0, 5.0),
+    math::Vector3d(0, 0, 1));
+  VerifyNondiagonalMomentsAndAxes(math::Vector3d(3000, 4999, 5001),
+    math::Vector3d(3000.0, 5000.0, 5000.0),
     math::Vector3d(0, 0, 1));
   // Non-diagonal inertia matrix with f1 = 0
   VerifyNondiagonalMomentsAndAxes(math::Vector3d(3, 4, 6),


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a bug in the tolerances used by `MassMatrix3::PrincipalAxesOffset`

## Summary

The `MassMatrix3::PrincipalAxesOffset` API accepts a relative tolerance parameter `_tol` (default `1e-6`) but was erroneously using the local variable `tol` when calling `PrincipalMoments`. This was causing inertia visuals to render improperly, with the `EquivalentBox` rotation not matching the principal moments. This includes new tests to cover the relative tolerance behavior and demonstrate the bug (build and run tests for https://github.com/ignitionrobotics/ign-math/commit/3776a65f991385ca150bce54913cdee8566a811e to confirm) and fixes it in https://github.com/ignitionrobotics/ign-math/commit/478ccf817424cc62c832ac6dac30d99ef0ad8303. The fix could have been just one character (`tol` -> `_tol`), but I moved the statement up above the definition of `tol` just to be safe.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
