### PR TITLE
Convert remaining #include statements to use gz/

### DIFF
--- a/eigen3/src/Conversions_TEST.cc
+++ b/eigen3/src/Conversions_TEST.cc
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/math/eigen3/Conversions.hh>
+#include <gz/math/eigen3/Conversions.hh>
 
 /////////////////////////////////////////////////
 /// Check Vector3 conversions

--- a/eigen3/src/Util_TEST.cc
+++ b/eigen3/src/Util_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/math/eigen3/Util.hh>
+#include <gz/math/eigen3/Util.hh>
 
 using namespace ignition;
 

--- a/include/gz/math/VolumetricGridLookupField.hh
+++ b/include/gz/math/VolumetricGridLookupField.hh
@@ -21,10 +21,10 @@
 #include <vector>
 #include <optional>
 
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/detail/InterpolationPoint.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/detail/InterpolationPoint.hh>
 
-#include <ignition/math/detail/AxisIndex.hh>
+#include <gz/math/detail/AxisIndex.hh>
 
 namespace ignition
 {

--- a/include/gz/math/detail/AxisIndex.hh
+++ b/include/gz/math/detail/AxisIndex.hh
@@ -25,7 +25,7 @@
 
 #include <cassert>
 
-#include <ignition/math/detail/InterpolationPoint.hh>
+#include <gz/math/detail/InterpolationPoint.hh>
 
 namespace ignition
 {

--- a/include/gz/math/detail/InterpolationPoint.hh
+++ b/include/gz/math/detail/InterpolationPoint.hh
@@ -18,8 +18,8 @@
 #ifndef IGNITION_MATH_INTERPOLATION_POINT_HH_
 #define IGNITION_MATH_INTERPOLATION_POINT_HH_
 
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/Vector2.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Vector2.hh>
 
 #include <optional>
 #include <vector>

--- a/src/AdditivelySeparableScalarField3_TEST.cc
+++ b/src/AdditivelySeparableScalarField3_TEST.cc
@@ -18,8 +18,8 @@
 #include <functional>
 #include <ostream>
 
-#include "ignition/math/AdditivelySeparableScalarField3.hh"
-#include "ignition/math/Polynomial3.hh"
+#include "gz/math/AdditivelySeparableScalarField3.hh"
+#include "gz/math/Polynomial3.hh"
 
 using namespace ignition;
 

--- a/src/Angle.cc
+++ b/src/Angle.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Angle.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Angle.hh"
 
 using namespace ignition::math;
 

--- a/src/Angle_TEST.cc
+++ b/src/Angle_TEST.cc
@@ -19,8 +19,8 @@
 
 #include <cmath>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Angle.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Angle.hh"
 
 using namespace ignition;
 

--- a/src/AxisAlignedBox.cc
+++ b/src/AxisAlignedBox.cc
@@ -15,7 +15,7 @@
  *
 */
 #include <cmath>
-#include <ignition/math/AxisAlignedBox.hh>
+#include <gz/math/AxisAlignedBox.hh>
 
 using namespace ignition;
 using namespace math;

--- a/src/AxisAlignedBox_TEST.cc
+++ b/src/AxisAlignedBox_TEST.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-#include "ignition/math/AxisAlignedBox.hh"
+#include "gz/math/AxisAlignedBox.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-#include "ignition/math/Box.hh"
+#include "gz/math/Box.hh"
 
 using namespace ignition;
 

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -18,8 +18,8 @@
 #include <cmath>
 #include <iostream>
 
-#include "ignition/math/Capsule.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Capsule.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 

--- a/src/Color.cc
+++ b/src/Color.cc
@@ -17,7 +17,7 @@
 #include <cmath>
 #include <algorithm>
 
-#include "ignition/math/Color.hh"
+#include "gz/math/Color.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Color_TEST.cc
+++ b/src/Color_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
-#include <ignition/math/Color.hh>
+#include <gz/math/Color.hh>
 
 using namespace ignition;
 

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -18,7 +18,7 @@
 #include <cmath>
 #include <iostream>
 
-#include "ignition/math/Cylinder.hh"
+#include "gz/math/Cylinder.hh"
 
 using namespace ignition;
 

--- a/src/DiffDriveOdometry.cc
+++ b/src/DiffDriveOdometry.cc
@@ -15,8 +15,8 @@
  *
 */
 #include <cmath>
-#include "ignition/math/DiffDriveOdometry.hh"
-#include "ignition/math/RollingMean.hh"
+#include "gz/math/DiffDriveOdometry.hh"
+#include "gz/math/RollingMean.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/DiffDriveOdometry_TEST.cc
+++ b/src/DiffDriveOdometry_TEST.cc
@@ -18,9 +18,9 @@
 #include <gtest/gtest.h>
 #include <thread>
 
-#include "ignition/math/Angle.hh"
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/DiffDriveOdometry.hh"
+#include "gz/math/Angle.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/DiffDriveOdometry.hh"
 
 using namespace ignition;
 

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -18,9 +18,9 @@
 #include <cmath>
 #include <iostream>
 
-#include "ignition/math/Ellipsoid.hh"
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Vector3.hh"
+#include "gz/math/Ellipsoid.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Vector3.hh"
 
 using namespace ignition;
 

--- a/src/Filter_TEST.cc
+++ b/src/Filter_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Filter.hh"
+#include "gz/math/Filter.hh"
 
 using namespace ignition;
 

--- a/src/Frustum.cc
+++ b/src/Frustum.cc
@@ -19,12 +19,12 @@
 #include <array>
 #include <utility>
 
-#include "ignition/math/Angle.hh"
-#include "ignition/math/AxisAlignedBox.hh"
-#include "ignition/math/Frustum.hh"
-#include "ignition/math/Matrix4.hh"
-#include "ignition/math/Plane.hh"
-#include "ignition/math/Pose3.hh"
+#include "gz/math/Angle.hh"
+#include "gz/math/AxisAlignedBox.hh"
+#include "gz/math/Frustum.hh"
+#include "gz/math/Matrix4.hh"
+#include "gz/math/Plane.hh"
+#include "gz/math/Pose3.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Frustum_TEST.cc
+++ b/src/Frustum_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Frustum.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Frustum.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/GaussMarkovProcess.cc
+++ b/src/GaussMarkovProcess.cc
@@ -15,8 +15,8 @@
  *
 */
 
-#include <ignition/math/GaussMarkovProcess.hh>
-#include <ignition/math/Rand.hh>
+#include <gz/math/GaussMarkovProcess.hh>
+#include <gz/math/Rand.hh>
 
 using namespace ignition::math;
 

--- a/src/GaussMarkovProcess_TEST.cc
+++ b/src/GaussMarkovProcess_TEST.cc
@@ -17,9 +17,9 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/GaussMarkovProcess.hh"
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Rand.hh"
+#include "gz/math/GaussMarkovProcess.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Rand.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Helpers.cc
+++ b/src/Helpers.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Helpers.hh"
 
 #include <iomanip>
 #include <regex>

--- a/src/Helpers.i
+++ b/src/Helpers.i
@@ -22,7 +22,7 @@
 
 %module helpers
 %{
-#include <ignition/math/Helpers.hh>
+#include <gz/math/Helpers.hh>
 %}
 
 template <typename T>

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -21,10 +21,10 @@
 #include <cmath>
 #include <limits>
 
-#include "ignition/math/Rand.hh"
-#include "ignition/math/Vector3.hh"
-#include "ignition/math/Helpers.hh"
-#include <ignition/utils/SuppressWarning.hh>
+#include "gz/math/Rand.hh"
+#include "gz/math/Vector3.hh"
+#include "gz/math/Helpers.hh"
+#include <gz/utils/SuppressWarning.hh>
 
 using namespace ignition;
 

--- a/src/Inertial_TEST.cc
+++ b/src/Inertial_TEST.cc
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-#include "ignition/math/Inertial.hh"
+#include "gz/math/Inertial.hh"
 
 using namespace ignition;
 

--- a/src/Interval_TEST.cc
+++ b/src/Interval_TEST.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <ostream>
 
-#include "ignition/math/Interval.hh"
+#include "gz/math/Interval.hh"
 
 using namespace ignition;
 

--- a/src/Kmeans.cc
+++ b/src/Kmeans.cc
@@ -15,11 +15,11 @@
  *
 */
 
-#include <ignition/math/Kmeans.hh>
+#include <gz/math/Kmeans.hh>
 
 #include <iostream>
 
-#include <ignition/math/Rand.hh>
+#include <gz/math/Rand.hh>
 #include "KmeansPrivate.hh"
 
 using namespace ignition;

--- a/src/KmeansPrivate.hh
+++ b/src/KmeansPrivate.hh
@@ -18,9 +18,9 @@
 #define IGNITION_MATH_KMEANSPRIVATE_HH_
 
 #include <vector>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/config.hh>
 
 namespace ignition
 {

--- a/src/Kmeans_TEST.cc
+++ b/src/Kmeans_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <vector>
-#include "ignition/math/Kmeans.hh"
+#include "gz/math/Kmeans.hh"
 
 using namespace ignition;
 

--- a/src/Line2_TEST.cc
+++ b/src/Line2_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Line2.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Line2.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 

--- a/src/Line3_TEST.cc
+++ b/src/Line3_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Line3.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Line3.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 

--- a/src/MassMatrix3_TEST.cc
+++ b/src/MassMatrix3_TEST.cc
@@ -18,9 +18,9 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/MassMatrix3.hh"
-#include "ignition/math/Material.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/MassMatrix3.hh"
+#include "gz/math/Material.hh"
 
 using namespace ignition;
 

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -15,12 +15,12 @@
  *
 */
 
-#include "ignition/math/Material.hh"
+#include "gz/math/Material.hh"
 
 #include <algorithm>
 #include <memory>
 
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Helpers.hh"
 
 // Placing the kMaterialData in a separate file for conveniece and clarity.
 #include "MaterialType.hh"

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -16,9 +16,9 @@
 */
 
 #include <gtest/gtest.h>
-#include "ignition/math/Material.hh"
-#include "ignition/math/MaterialType.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Material.hh"
+#include "gz/math/MaterialType.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Matrix3.i
+++ b/src/Matrix3.i
@@ -22,7 +22,7 @@
 
 %module matrix3
 %{
-#include <ignition/math/Matrix3.hh>
+#include <gz/math/Matrix3.hh>
 %}
 
 namespace ignition

--- a/src/Matrix3_TEST.cc
+++ b/src/Matrix3_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Matrix3.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Matrix3.hh"
 
 using namespace ignition;
 

--- a/src/Matrix4_TEST.cc
+++ b/src/Matrix4_TEST.cc
@@ -17,10 +17,10 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Matrix4.hh"
-#include "ignition/math/Pose3.hh"
-#include "ignition/math/Quaternion.hh"
-#include "ignition/math/Vector3.hh"
+#include "gz/math/Matrix4.hh"
+#include "gz/math/Pose3.hh"
+#include "gz/math/Quaternion.hh"
+#include "gz/math/Vector3.hh"
 
 using namespace ignition;
 

--- a/src/MovingWindowFilter_TEST.cc
+++ b/src/MovingWindowFilter_TEST.cc
@@ -16,8 +16,8 @@
 */
 
 #include <gtest/gtest.h>
-#include "ignition/math/Vector3.hh"
-#include "ignition/math/MovingWindowFilter.hh"
+#include "gz/math/Vector3.hh"
+#include "gz/math/MovingWindowFilter.hh"
 
 using namespace ignition;
 

--- a/src/OrientedBox_TEST.cc
+++ b/src/OrientedBox_TEST.cc
@@ -17,8 +17,8 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-#include "ignition/math/Angle.hh"
-#include "ignition/math/OrientedBox.hh"
+#include "gz/math/Angle.hh"
+#include "gz/math/OrientedBox.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/PID.cc
+++ b/src/PID.cc
@@ -17,8 +17,8 @@
 
 #include <chrono>
 #include <cmath>
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/PID.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/PID.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/PID_TEST.cc
+++ b/src/PID_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/PID.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/PID.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 

--- a/src/PiecewiseScalarField3_TEST.cc
+++ b/src/PiecewiseScalarField3_TEST.cc
@@ -19,10 +19,10 @@
 #include <cmath>
 #include <functional>
 
-#include "ignition/math/AdditivelySeparableScalarField3.hh"
-#include "ignition/math/PiecewiseScalarField3.hh"
-#include "ignition/math/Polynomial3.hh"
-#include "ignition/math/Vector3.hh"
+#include "gz/math/AdditivelySeparableScalarField3.hh"
+#include "gz/math/PiecewiseScalarField3.hh"
+#include "gz/math/Polynomial3.hh"
+#include "gz/math/Vector3.hh"
 
 using namespace ignition;
 

--- a/src/Plane_TEST.cc
+++ b/src/Plane_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Plane.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Plane.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Polynomial3_TEST.cc
+++ b/src/Polynomial3_TEST.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <ostream>
 
-#include "ignition/math/Polynomial3.hh"
+#include "gz/math/Polynomial3.hh"
 
 using namespace ignition;
 

--- a/src/Pose3.i
+++ b/src/Pose3.i
@@ -22,7 +22,7 @@
 
 %module pose3
 %{
-#include <ignition/math/Pose3.hh>
+#include <gz/math/Pose3.hh>
 %}
 
 namespace ignition

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -17,9 +17,9 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Pose3.hh>
-#include <ignition/utils/SuppressWarning.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/utils/SuppressWarning.hh>
 
 using namespace ignition;
 

--- a/src/Quaternion.i
+++ b/src/Quaternion.i
@@ -22,7 +22,7 @@
 
 %module quaternion
 %{
-#include <ignition/math/Quaternion.hh>
+#include <gz/math/Quaternion.hh>
 %}
 
 namespace ignition

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -19,11 +19,11 @@
 
 #include <cmath>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Quaternion.hh"
-#include "ignition/math/Matrix3.hh"
-#include "ignition/math/Matrix4.hh"
-#include <ignition/utils/SuppressWarning.hh>
+#include "gz/math/Helpers.hh"
+#include "gz/math/Quaternion.hh"
+#include "gz/math/Matrix3.hh"
+#include "gz/math/Matrix4.hh"
+#include <gz/utils/SuppressWarning.hh>
 
 using namespace ignition;
 

--- a/src/Rand.cc
+++ b/src/Rand.cc
@@ -25,7 +25,7 @@
   #include <unistd.h>
 #endif
 
-#include "ignition/math/Rand.hh"
+#include "gz/math/Rand.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Rand_TEST.cc
+++ b/src/Rand_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Rand.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Rand.hh"
 
 using namespace ignition;
 

--- a/src/Region3_TEST.cc
+++ b/src/Region3_TEST.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <ostream>
 
-#include "ignition/math/Region3.hh"
+#include "gz/math/Region3.hh"
 
 using namespace ignition;
 

--- a/src/RollingMean.cc
+++ b/src/RollingMean.cc
@@ -18,7 +18,7 @@
 #include <numeric>
 #include <limits>
 #include <deque>
-#include "ignition/math/RollingMean.hh"
+#include "gz/math/RollingMean.hh"
 
 using namespace ignition::math;
 

--- a/src/RollingMean_TEST.cc
+++ b/src/RollingMean_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/RollingMean.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/RollingMean.hh"
 
 using namespace ignition;
 

--- a/src/RotationSpline.cc
+++ b/src/RotationSpline.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#include "ignition/math/Quaternion.hh"
-#include "ignition/math/RotationSpline.hh"
+#include "gz/math/Quaternion.hh"
+#include "gz/math/RotationSpline.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/RotationSpline_TEST.cc
+++ b/src/RotationSpline_TEST.cc
@@ -17,10 +17,10 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Vector3.hh"
-#include "ignition/math/Quaternion.hh"
-#include "ignition/math/RotationSpline.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Vector3.hh"
+#include "gz/math/Quaternion.hh"
+#include "gz/math/RotationSpline.hh"
 
 using namespace ignition;
 

--- a/src/SemanticVersion.cc
+++ b/src/SemanticVersion.cc
@@ -17,7 +17,7 @@
 
 #include <sstream>
 
-#include "ignition/math/SemanticVersion.hh"
+#include "gz/math/SemanticVersion.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/SemanticVersion_TEST.cc
+++ b/src/SemanticVersion_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/SemanticVersion.hh"
+#include "gz/math/SemanticVersion.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/SignalStats.cc
+++ b/src/SignalStats.cc
@@ -16,7 +16,7 @@
 */
 #include <cmath>
 #include <iostream>
-#include <ignition/math/SignalStats.hh>
+#include <gz/math/SignalStats.hh>
 #include "SignalStatsPrivate.hh"
 
 using namespace ignition;

--- a/src/SignalStatsPrivate.hh
+++ b/src/SignalStatsPrivate.hh
@@ -19,7 +19,7 @@
 
 #include <memory>
 #include <vector>
-#include <ignition/math/config.hh>
+#include <gz/math/config.hh>
 
 namespace ignition
 {

--- a/src/SignalStats_TEST.cc
+++ b/src/SignalStats_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/math/Rand.hh>
-#include <ignition/math/SignalStats.hh>
+#include <gz/math/Rand.hh>
+#include <gz/math/SignalStats.hh>
 
 using namespace ignition;
 

--- a/src/SpeedLimiter.cc
+++ b/src/SpeedLimiter.cc
@@ -15,8 +15,8 @@
  *
 */
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/SpeedLimiter.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/SpeedLimiter.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/SpeedLimiter_TEST.cc
+++ b/src/SpeedLimiter_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/SpeedLimiter.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/SpeedLimiter.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Sphere_TEST.cc
+++ b/src/Sphere_TEST.cc
@@ -18,7 +18,7 @@
 #include <cmath>
 #include <iostream>
 
-#include "ignition/math/Sphere.hh"
+#include "gz/math/Sphere.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <string>
 
-#include "ignition/math/Matrix3.hh"
-#include "ignition/math/SphericalCoordinates.hh"
+#include "gz/math/Matrix3.hh"
+#include "gz/math/SphericalCoordinates.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/SphericalCoordinates_TEST.cc
+++ b/src/SphericalCoordinates_TEST.cc
@@ -16,7 +16,7 @@
 */
 #include <gtest/gtest.h>
 
-#include "ignition/math/SphericalCoordinates.hh"
+#include "gz/math/SphericalCoordinates.hh"
 
 using namespace ignition;
 

--- a/src/Spline.cc
+++ b/src/Spline.cc
@@ -17,9 +17,9 @@
 // Note: Originally cribbed from Ogre3d. Modified to implement Cardinal
 // spline and catmull-rom spline
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Vector4.hh"
-#include "ignition/math/Spline.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Vector4.hh"
+#include "gz/math/Spline.hh"
 
 #include "SplinePrivate.hh"
 

--- a/src/SplinePrivate.cc
+++ b/src/SplinePrivate.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include "ignition/math/Matrix4.hh"
+#include "gz/math/Matrix4.hh"
 
 #include "SplinePrivate.hh"
 

--- a/src/SplinePrivate.hh
+++ b/src/SplinePrivate.hh
@@ -19,11 +19,11 @@
 
 #include <algorithm>
 #include <vector>
-#include <ignition/math/Matrix4.hh>
-#include <ignition/math/Spline.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/Vector4.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/Matrix4.hh>
+#include <gz/math/Spline.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Vector4.hh>
+#include <gz/math/config.hh>
 
 namespace ignition
 {

--- a/src/Spline_TEST.cc
+++ b/src/Spline_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Vector3.hh"
-#include "ignition/math/Spline.hh"
+#include "gz/math/Vector3.hh"
+#include "gz/math/Spline.hh"
 
 using namespace ignition;
 

--- a/src/Stopwatch.cc
+++ b/src/Stopwatch.cc
@@ -15,7 +15,7 @@
  *
 */
 #include <chrono>
-#include "ignition/math/Stopwatch.hh"
+#include "gz/math/Stopwatch.hh"
 
 using namespace ignition::math;
 

--- a/src/Stopwatch_TEST.cc
+++ b/src/Stopwatch_TEST.cc
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 #include <thread>
 
-#include "ignition/math/Stopwatch.hh"
+#include "gz/math/Stopwatch.hh"
 
 using namespace ignition;
 

--- a/src/Temperature.cc
+++ b/src/Temperature.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include "ignition/math/Temperature.hh"
+#include "gz/math/Temperature.hh"
 
 #include <istream>
 #include <ostream>

--- a/src/Temperature.i
+++ b/src/Temperature.i
@@ -17,7 +17,7 @@
 
 %module temperature
 %{
-#include <ignition/math/Temperature.hh>
+#include <gz/math/Temperature.hh>
 %}
 
 namespace ignition

--- a/src/Temperature_TEST.cc
+++ b/src/Temperature_TEST.cc
@@ -16,7 +16,7 @@
 */
 #include <gtest/gtest.h>
 
-#include "ignition/math/Temperature.hh"
+#include "gz/math/Temperature.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Triangle3_TEST.cc
+++ b/src/Triangle3_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Triangle3.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Triangle3.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/Triangle_TEST.cc
+++ b/src/Triangle_TEST.cc
@@ -17,8 +17,8 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Triangle.hh"
-#include "ignition/math/Helpers.hh"
+#include "gz/math/Triangle.hh"
+#include "gz/math/Helpers.hh"
 
 using namespace ignition;
 

--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -18,8 +18,8 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Vector2.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Vector2.hh"
 
 using namespace ignition;
 

--- a/src/Vector3Stats.cc
+++ b/src/Vector3Stats.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <ignition/math/Vector3Stats.hh>
+#include <gz/math/Vector3Stats.hh>
 
 using namespace ignition;
 using namespace math;

--- a/src/Vector3Stats_TEST.cc
+++ b/src/Vector3Stats_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/math/Vector3Stats.hh>
+#include <gz/math/Vector3Stats.hh>
 
 using namespace ignition;
 

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -20,8 +20,8 @@
 #include <numeric>
 #include <sstream>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Vector3.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Vector3.hh"
 
 using namespace ignition;
 

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -17,9 +17,9 @@
 
 #include <gtest/gtest.h>
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Matrix4.hh"
-#include "ignition/math/Vector4.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Matrix4.hh"
+#include "gz/math/Vector4.hh"
 
 using namespace ignition;
 

--- a/src/graph/Edge_TEST.cc
+++ b/src/graph/Edge_TEST.cc
@@ -19,8 +19,8 @@
 #include <iostream>
 #include <string>
 
-#include "ignition/math/graph/Edge.hh"
-#include "ignition/math/graph/Vertex.hh"
+#include "gz/math/graph/Edge.hh"
+#include "gz/math/graph/Vertex.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -18,8 +18,8 @@
 #include <gtest/gtest.h>
 #include <string>
 
-#include "ignition/math/graph/Graph.hh"
-#include "ignition/math/graph/GraphAlgorithms.hh"
+#include "gz/math/graph/Graph.hh"
+#include "gz/math/graph/GraphAlgorithms.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/graph/GraphDirected_TEST.cc
+++ b/src/graph/GraphDirected_TEST.cc
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <string>
 
-#include "ignition/math/graph/Graph.hh"
+#include "gz/math/graph/Graph.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/graph/GraphUndirected_TEST.cc
+++ b/src/graph/GraphUndirected_TEST.cc
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "ignition/math/graph/Graph.hh"
+#include "gz/math/graph/Graph.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/graph/Graph_TEST.cc
+++ b/src/graph/Graph_TEST.cc
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 #include <string>
 
-#include "ignition/math/graph/Graph.hh"
+#include "gz/math/graph/Graph.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/graph/Vertex_TEST.cc
+++ b/src/graph/Vertex_TEST.cc
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <string>
 
-#include "ignition/math/graph/Vertex.hh"
+#include "gz/math/graph/Vertex.hh"
 
 using namespace ignition;
 using namespace math;

--- a/src/python_pybind11/src/Angle.cc
+++ b/src/python_pybind11/src/Angle.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <string>
 
-#include <ignition/math/Angle.hh>
+#include <gz/math/Angle.hh>
 #include <pybind11/operators.h>
 
 #include "Angle.hh"

--- a/src/python_pybind11/src/AxisAlignedBox.cc
+++ b/src/python_pybind11/src/AxisAlignedBox.cc
@@ -22,8 +22,8 @@
 
 #include "AxisAlignedBox.hh"
 
-#include <ignition/math/AxisAlignedBox.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/Vector3.hh>
 
 using namespace pybind11::literals;
 

--- a/src/python_pybind11/src/Box.hh
+++ b/src/python_pybind11/src/Box.hh
@@ -25,7 +25,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Box.hh>
+#include <gz/math/Box.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Capsule.hh
+++ b/src/python_pybind11/src/Capsule.hh
@@ -24,7 +24,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Capsule.hh>
+#include <gz/math/Capsule.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Color.cc
+++ b/src/python_pybind11/src/Color.cc
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "Color.hh"
-#include <ignition/math/Color.hh>
+#include <gz/math/Color.hh>
 
 #include <pybind11/operators.h>
 

--- a/src/python_pybind11/src/Cylinder.hh
+++ b/src/python_pybind11/src/Cylinder.hh
@@ -24,7 +24,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Cylinder.hh>
+#include <gz/math/Cylinder.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/DiffDriveOdometry.hh
+++ b/src/python_pybind11/src/DiffDriveOdometry.hh
@@ -22,7 +22,7 @@
 #include <pybind11/chrono.h>
 #include <string>
 
-#include <ignition/math/DiffDriveOdometry.hh>
+#include <gz/math/DiffDriveOdometry.hh>
 
 namespace py = pybind11;
 

--- a/src/python_pybind11/src/Ellipsoid.hh
+++ b/src/python_pybind11/src/Ellipsoid.hh
@@ -24,8 +24,8 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Ellipsoid.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Ellipsoid.hh>
+#include <gz/math/Vector3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Filter.hh
+++ b/src/python_pybind11/src/Filter.hh
@@ -22,9 +22,9 @@
 
 #include <pybind11/pybind11.h>
 
-#include <ignition/math/Filter.hh>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Filter.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
 
 namespace py = pybind11;
 

--- a/src/python_pybind11/src/Frustum.cc
+++ b/src/python_pybind11/src/Frustum.cc
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "Frustum.hh"
-#include <ignition/math/Frustum.hh>
+#include <gz/math/Frustum.hh>
 
 #include <pybind11/operators.h>
 #include <pybind11/stl_bind.h>

--- a/src/python_pybind11/src/GaussMarkovProcess.cc
+++ b/src/python_pybind11/src/GaussMarkovProcess.cc
@@ -22,7 +22,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/chrono.h>
 
-#include <ignition/math/GaussMarkovProcess.hh>
+#include <gz/math/GaussMarkovProcess.hh>
 
 #include "GaussMarkovProcess.hh"
 

--- a/src/python_pybind11/src/Helpers.cc
+++ b/src/python_pybind11/src/Helpers.cc
@@ -19,8 +19,8 @@
 #include <pybind11/stl.h>
 
 #include "Helpers.hh"
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Vector3.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/Inertial.hh
+++ b/src/python_pybind11/src/Inertial.hh
@@ -24,7 +24,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Inertial.hh>
+#include <gz/math/Inertial.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Kmeans.cc
+++ b/src/python_pybind11/src/Kmeans.cc
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "Kmeans.hh"
-#include <ignition/math/Kmeans.hh>
+#include <gz/math/Kmeans.hh>
 #include <pybind11/stl.h>
 
 namespace ignition

--- a/src/python_pybind11/src/Line2.hh
+++ b/src/python_pybind11/src/Line2.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Line2.hh>
+#include <gz/math/Line2.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Line3.hh
+++ b/src/python_pybind11/src/Line3.hh
@@ -24,8 +24,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Line3.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Line3.hh>
+#include <gz/math/Vector3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/MassMatrix3.hh
+++ b/src/python_pybind11/src/MassMatrix3.hh
@@ -22,8 +22,8 @@
 #include <pybind11/operators.h>
 #include <string>
 
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/MassMatrix3.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/MassMatrix3.hh>
 
 namespace py = pybind11;
 

--- a/src/python_pybind11/src/Material.cc
+++ b/src/python_pybind11/src/Material.cc
@@ -19,8 +19,8 @@
 #include <string>
 
 #include "Material.hh"
-#include <ignition/math/Material.hh>
-#include <ignition/math/MaterialType.hh>
+#include <gz/math/Material.hh>
+#include <gz/math/MaterialType.hh>
 
 #include <pybind11/operators.h>
 #include <pybind11/stl_bind.h>

--- a/src/python_pybind11/src/Matrix3.hh
+++ b/src/python_pybind11/src/Matrix3.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Matrix3.hh>
+#include <gz/math/Matrix3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Matrix4.hh
+++ b/src/python_pybind11/src/Matrix4.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Matrix4.hh>
+#include <gz/math/Matrix4.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/MovingWindowFilter.cc
+++ b/src/python_pybind11/src/MovingWindowFilter.cc
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Vector3.hh>
 #include "MovingWindowFilter.hh"
 
 namespace ignition

--- a/src/python_pybind11/src/MovingWindowFilter.hh
+++ b/src/python_pybind11/src/MovingWindowFilter.hh
@@ -22,7 +22,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <ignition/math/MovingWindowFilter.hh>
+#include <gz/math/MovingWindowFilter.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/OrientedBox.hh
+++ b/src/python_pybind11/src/OrientedBox.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/OrientedBox.hh>
+#include <gz/math/OrientedBox.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/PID.cc
+++ b/src/python_pybind11/src/PID.cc
@@ -18,7 +18,7 @@
 #include <pybind11/chrono.h>
 #include <string>
 
-#include <ignition/math/PID.hh>
+#include <gz/math/PID.hh>
 
 #include "PID.hh"
 

--- a/src/python_pybind11/src/Plane.hh
+++ b/src/python_pybind11/src/Plane.hh
@@ -24,7 +24,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Plane.hh>
+#include <gz/math/Plane.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Pose3.hh
+++ b/src/python_pybind11/src/Pose3.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Pose3.hh>
+#include <gz/math/Pose3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Quaternion.hh
+++ b/src/python_pybind11/src/Quaternion.hh
@@ -25,9 +25,9 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/Matrix3.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Matrix3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Rand.cc
+++ b/src/python_pybind11/src/Rand.cc
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "Rand.hh"
-#include <ignition/math/Rand.hh>
+#include <gz/math/Rand.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/RollingMean.cc
+++ b/src/python_pybind11/src/RollingMean.cc
@@ -16,7 +16,7 @@
 */
 #include <string>
 #include "RollingMean.hh"
-#include <ignition/math/RollingMean.hh>
+#include <gz/math/RollingMean.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/RotationSpline.cc
+++ b/src/python_pybind11/src/RotationSpline.cc
@@ -16,7 +16,7 @@
 */
 #include <string>
 #include "RotationSpline.hh"
-#include <ignition/math/RotationSpline.hh>
+#include <gz/math/RotationSpline.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/SemanticVersion.cc
+++ b/src/python_pybind11/src/SemanticVersion.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <string>
 
-#include <ignition/math/SemanticVersion.hh>
+#include <gz/math/SemanticVersion.hh>
 #include <pybind11/operators.h>
 
 #include "SemanticVersion.hh"

--- a/src/python_pybind11/src/SignalStats.cc
+++ b/src/python_pybind11/src/SignalStats.cc
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "SignalStats.hh"
-#include <ignition/math/SignalStats.hh>
+#include <gz/math/SignalStats.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/Sphere.hh
+++ b/src/python_pybind11/src/Sphere.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Sphere.hh>
+#include <gz/math/Sphere.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/SphericalCoordinates.cc
+++ b/src/python_pybind11/src/SphericalCoordinates.cc
@@ -17,8 +17,8 @@
 #include <pybind11/operators.h>
 
 #include "SphericalCoordinates.hh"
-#include <ignition/math/Angle.hh>
-#include <ignition/math/SphericalCoordinates.hh>
+#include <gz/math/Angle.hh>
+#include <gz/math/SphericalCoordinates.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/Spline.cc
+++ b/src/python_pybind11/src/Spline.cc
@@ -16,7 +16,7 @@
 */
 #include <string>
 #include "Spline.hh"
-#include <ignition/math/Spline.hh>
+#include <gz/math/Spline.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/StopWatch.cc
+++ b/src/python_pybind11/src/StopWatch.cc
@@ -21,7 +21,7 @@
 
 #include "StopWatch.hh"
 
-#include <ignition/math/Stopwatch.hh>
+#include <gz/math/Stopwatch.hh>
 
 namespace ignition
 {

--- a/src/python_pybind11/src/Temperature.cc
+++ b/src/python_pybind11/src/Temperature.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <string>
 
-#include <ignition/math/Temperature.hh>
+#include <gz/math/Temperature.hh>
 
 #include "Temperature.hh"
 #include <pybind11/operators.h>

--- a/src/python_pybind11/src/Triangle.hh
+++ b/src/python_pybind11/src/Triangle.hh
@@ -23,7 +23,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Triangle.hh>
+#include <gz/math/Triangle.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Triangle3.hh
+++ b/src/python_pybind11/src/Triangle3.hh
@@ -23,7 +23,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Triangle3.hh>
+#include <gz/math/Triangle3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Vector2.hh
+++ b/src/python_pybind11/src/Vector2.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Vector2.hh>
+#include <gz/math/Vector2.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Vector3.hh
+++ b/src/python_pybind11/src/Vector3.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Vector3.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/python_pybind11/src/Vector3Stats.cc
+++ b/src/python_pybind11/src/Vector3Stats.cc
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <ignition/math/Vector3Stats.hh>
+#include <gz/math/Vector3Stats.hh>
 
 #include "Vector3Stats.hh"
 

--- a/src/python_pybind11/src/Vector4.hh
+++ b/src/python_pybind11/src/Vector4.hh
@@ -24,7 +24,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <ignition/math/Vector4.hh>
+#include <gz/math/Vector4.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;

--- a/src/ruby/Angle.i
+++ b/src/ruby/Angle.i
@@ -17,7 +17,7 @@
 
 %module angle
 %{
-#include <ignition/math/Angle.hh>
+#include <gz/math/Angle.hh>
 %}
 
 namespace ignition

--- a/src/ruby/AxisAlignedBox.i
+++ b/src/ruby/AxisAlignedBox.i
@@ -19,11 +19,11 @@
 %{
 #include <iostream>
 #include <tuple>
-#include <ignition/math/AxisAlignedBox.hh>
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Line3.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Line3.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "typemaps.i"

--- a/src/ruby/Box.i
+++ b/src/ruby/Box.i
@@ -17,14 +17,14 @@
 
 %module box
 %{
-#include <ignition/math/Box.hh>
-#include <ignition/math/config.hh>
-#include <ignition/math/MassMatrix3.hh>
-#include <ignition/math/Material.hh>
-#include <ignition/math/Plane.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Box.hh>
+#include <gz/math/config.hh>
+#include <gz/math/MassMatrix3.hh>
+#include <gz/math/Material.hh>
+#include <gz/math/Plane.hh>
+#include <gz/math/Vector3.hh>
 
-#include "ignition/math/detail/WellOrderedVector.hh"
+#include "gz/math/detail/WellOrderedVector.hh"
 
 #include <set>
 #include <optional>

--- a/src/ruby/Color.i
+++ b/src/ruby/Color.i
@@ -18,10 +18,10 @@
 %module Color
 %{
 #include <sstream>
-#include <ignition/math/Color.hh>
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Color.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Cylinder.i
+++ b/src/ruby/Cylinder.i
@@ -17,11 +17,11 @@
 
 %module cylinder
 %{
-#include <ignition/math/Cylinder.hh>
-#include <ignition/math/config.hh>
-#include <ignition/math/MassMatrix3.hh>
-#include <ignition/math/Material.hh>
-#include <ignition/math/Quaternion.hh>
+#include <gz/math/Cylinder.hh>
+#include <gz/math/config.hh>
+#include <gz/math/MassMatrix3.hh>
+#include <gz/math/Material.hh>
+#include <gz/math/Quaternion.hh>
 %}
 
 namespace ignition

--- a/src/ruby/DiffDriveOdometry.i
+++ b/src/ruby/DiffDriveOdometry.i
@@ -19,10 +19,10 @@
 %{
 #include <chrono>
 #include <memory>
-#include <ignition/math/DiffDriveOdometry.hh>
-#include <ignition/math/Angle.hh>
-#include <ignition/math/Export.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/DiffDriveOdometry.hh>
+#include <gz/math/Angle.hh>
+#include <gz/math/Export.hh>
+#include <gz/math/config.hh>
 %}
 
 %include "typemaps.i"

--- a/src/ruby/Filter.i
+++ b/src/ruby/Filter.i
@@ -17,11 +17,11 @@
 
 %module filter
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Filter.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Filter.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %import Quaternion.i

--- a/src/ruby/Frustum.i
+++ b/src/ruby/Frustum.i
@@ -17,12 +17,12 @@
 
 %module frustum
 %{
-#include <ignition/math/Frustum.hh>
-#include <ignition/math/Angle.hh>
-#include <ignition/math/AxisAlignedBox.hh>
-#include <ignition/math/Plane.hh>
-#include <ignition/math/Pose3.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/Frustum.hh>
+#include <gz/math/Angle.hh>
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/Plane.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/config.hh>
 %}
 
 namespace ignition

--- a/src/ruby/GaussMarkovProcess.i
+++ b/src/ruby/GaussMarkovProcess.i
@@ -17,7 +17,7 @@
 
 %module gaussMarkovProcess
 %{
-#include <ignition/math/GaussMarkovProcess.hh>
+#include <gz/math/GaussMarkovProcess.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Helpers.i
+++ b/src/ruby/Helpers.i
@@ -17,7 +17,7 @@
 
 %module helpers
 %{
-#include <ignition/math/Helpers.hh>
+#include <gz/math/Helpers.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Inertial.i
+++ b/src/ruby/Inertial.i
@@ -17,10 +17,10 @@
 
 %module inertial
 %{
-#include <ignition/math/Inertial.hh>
-#include <ignition/math/config.hh>
-#include "ignition/math/MassMatrix3.hh"
-#include "ignition/math/Pose3.hh"
+#include <gz/math/Inertial.hh>
+#include <gz/math/config.hh>
+#include "gz/math/MassMatrix3.hh"
+#include "gz/math/Pose3.hh"
 %}
 
 namespace ignition

--- a/src/ruby/Kmeans.i
+++ b/src/ruby/Kmeans.i
@@ -17,9 +17,9 @@
 
 %module kmeans
 %{
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/Kmeans.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Kmeans.hh>
 %}
 
 %include "std_vector.i"

--- a/src/ruby/Line2.i
+++ b/src/ruby/Line2.i
@@ -18,9 +18,9 @@
 %module line2
 %{
 #include <sstream>
-#include <ignition/math/Line2.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Vector2.hh>
+#include <gz/math/Line2.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Vector2.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Line3.i
+++ b/src/ruby/Line3.i
@@ -18,9 +18,9 @@
 %module line3
 %{
 #include <sstream>
-#include <ignition/math/Line3.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Line3.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/MassMatrix3.i
+++ b/src/ruby/MassMatrix3.i
@@ -17,14 +17,14 @@
 
 %module massmatrix3
 %{
-#include "ignition/math/MassMatrix3.hh"
+#include "gz/math/MassMatrix3.hh"
 
-#include "ignition/math/Helpers.hh"
-#include "ignition/math/Material.hh"
-#include "ignition/math/Quaternion.hh"
-#include "ignition/math/Vector2.hh"
-#include "ignition/math/Vector3.hh"
-#include "ignition/math/Matrix3.hh"
+#include "gz/math/Helpers.hh"
+#include "gz/math/Material.hh"
+#include "gz/math/Quaternion.hh"
+#include "gz/math/Vector2.hh"
+#include "gz/math/Vector3.hh"
+#include "gz/math/Matrix3.hh"
 %}
 
 namespace ignition

--- a/src/ruby/Material.i
+++ b/src/ruby/Material.i
@@ -17,10 +17,10 @@
 
 %module material
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Export.hh>
-#include <ignition/math/Material.hh>
-#include <ignition/math/MaterialType.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Export.hh>
+#include <gz/math/Material.hh>
+#include <gz/math/MaterialType.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/MaterialType.i
+++ b/src/ruby/MaterialType.i
@@ -17,9 +17,9 @@
 
 %module materialtype
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Export.hh>
-#include <ignition/math/MaterialType.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Export.hh>
+#include <gz/math/MaterialType.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Matrix3.i
+++ b/src/ruby/Matrix3.i
@@ -17,11 +17,11 @@
 
 %module matrix3
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Matrix3.hh>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Matrix3.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Matrix4.i
+++ b/src/ruby/Matrix4.i
@@ -17,12 +17,12 @@
 
 %module matrix4
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Matrix3.hh>
-#include <ignition/math/Matrix4.hh>
-#include <ignition/math/Pose3.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Matrix3.hh>
+#include <gz/math/Matrix4.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/MovingWindowFilter.i
+++ b/src/ruby/MovingWindowFilter.i
@@ -16,8 +16,8 @@
 */
 %module movingwindowfilter
 %{
-#include "ignition/math/MovingWindowFilter.hh"
-#include "ignition/math/Vector3.hh"
+#include "gz/math/MovingWindowFilter.hh"
+#include "gz/math/Vector3.hh"
 %}
 
 namespace ignition

--- a/src/ruby/OrientedBox.i
+++ b/src/ruby/OrientedBox.i
@@ -18,14 +18,14 @@
 %module orientedbox
 %{
 #include <iostream>
-#include <ignition/math/OrientedBox.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/MassMatrix3.hh>
-#include <ignition/math/Material.hh>
-#include <ignition/math/Matrix4.hh>
-#include <ignition/math/Pose3.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/OrientedBox.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/MassMatrix3.hh>
+#include <gz/math/Material.hh>
+#include <gz/math/Matrix4.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/config.hh>
 %}
 
 namespace ignition

--- a/src/ruby/PID.i
+++ b/src/ruby/PID.i
@@ -16,7 +16,7 @@
 */
 %module pid 
 %{
-	#include <ignition/math/PID.hh>
+	#include <gz/math/PID.hh>
 %}
 
 %include "typemaps.i"

--- a/src/ruby/Plane.i
+++ b/src/ruby/Plane.i
@@ -17,13 +17,13 @@
 
 %module plane
 %{
-#include <ignition/math/Plane.hh>
-#include <ignition/math/AxisAlignedBox.hh>
-#include <ignition/math/Vector2.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/config.hh>
-#include <ignition/math/Line2.hh>
-#include <ignition/math/Quaternion.hh>
+#include <gz/math/Plane.hh>
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/Vector2.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Line2.hh>
+#include <gz/math/Quaternion.hh>
 #include <optional>
 %}
 

--- a/src/ruby/Pose3.i
+++ b/src/ruby/Pose3.i
@@ -17,10 +17,10 @@
 
 %module quaternion
 %{
-  #include <ignition/math/config.hh>
-  #include <ignition/math/Pose3.hh>
-  #include <ignition/math/Quaternion.hh>
-  #include <ignition/math/Vector3.hh>
+  #include <gz/math/config.hh>
+  #include <gz/math/Pose3.hh>
+  #include <gz/math/Quaternion.hh>
+  #include <gz/math/Vector3.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Quaternion.i
+++ b/src/ruby/Quaternion.i
@@ -17,10 +17,10 @@
 
 %module quaternion
 %{
-#include <ignition/math/Angle.hh>
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Angle.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Rand.i
+++ b/src/ruby/Rand.i
@@ -17,7 +17,7 @@
 
 %module rand
 %{
-#include <ignition/math/Rand.hh>
+#include <gz/math/Rand.hh>
 %}
 
 namespace ignition

--- a/src/ruby/RollingMean.i
+++ b/src/ruby/RollingMean.i
@@ -17,7 +17,7 @@
 
 %module rollingMean
 %{
-#include <ignition/math/RollingMean.hh>
+#include <gz/math/RollingMean.hh>
 %}
 
 namespace ignition

--- a/src/ruby/RotationSpline.i
+++ b/src/ruby/RotationSpline.i
@@ -17,9 +17,9 @@
 
 %module rotationspline
 %{
-#include <ignition/math/RotationSpline.hh>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/RotationSpline.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/config.hh>
 %}
 
 namespace ignition

--- a/src/ruby/SemanticVersion.i
+++ b/src/ruby/SemanticVersion.i
@@ -18,7 +18,7 @@
 %module semanticversion
 %{
   #include <sstream>
-	#include <ignition/math/SemanticVersion.hh>
+	#include <gz/math/SemanticVersion.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/SignalStats.i
+++ b/src/ruby/SignalStats.i
@@ -18,7 +18,7 @@
 %module signalStats
 
 %{
-#include <ignition/math/SignalStats.hh>
+#include <gz/math/SignalStats.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Sphere.i
+++ b/src/ruby/Sphere.i
@@ -17,11 +17,11 @@
 
 %module sphere
 %{
-#include "ignition/math/Sphere.hh"
-#include "ignition/math/MassMatrix3.hh"
-#include "ignition/math/Material.hh"
-#include "ignition/math/Quaternion.hh"
-#include "ignition/math/Plane.hh"
+#include "gz/math/Sphere.hh"
+#include "gz/math/MassMatrix3.hh"
+#include "gz/math/Material.hh"
+#include "gz/math/Quaternion.hh"
+#include "gz/math/Plane.hh"
 %}
 
 %include "typemaps.i"

--- a/src/ruby/SphericalCoordinates.i
+++ b/src/ruby/SphericalCoordinates.i
@@ -20,10 +20,10 @@
 #include <memory>
 #include <string>
 
-#include <ignition/math/SphericalCoordinates.hh>
-#include <ignition/math/Angle.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/config.hh>
+#include <gz/math/SphericalCoordinates.hh>
+#include <gz/math/Angle.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/config.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Spline.i
+++ b/src/ruby/Spline.i
@@ -17,10 +17,10 @@
 
 %module spline
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Spline.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Spline.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 namespace ignition

--- a/src/ruby/StopWatch.i
+++ b/src/ruby/StopWatch.i
@@ -19,9 +19,9 @@
 %{
 #include <chrono>
 #include <memory>
-#include "ignition/math/Stopwatch.hh"
-#include <ignition/math/Export.hh>
-#include <ignition/math/config.hh>
+#include "gz/math/Stopwatch.hh"
+#include <gz/math/Export.hh>
+#include <gz/math/config.hh>
 %}
 
 %include "typemaps.i"

--- a/src/ruby/Temperature.i
+++ b/src/ruby/Temperature.i
@@ -18,7 +18,7 @@
 %module temperature
 %{
 #include <sstream>
-#include <ignition/math/Temperature.hh>
+#include <gz/math/Temperature.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Triangle.i
+++ b/src/ruby/Triangle.i
@@ -17,12 +17,12 @@
 
 %module triangle
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Line2.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Line2.hh>
 #include <set>
-#include <ignition/math/Triangle.hh>
-#include <ignition/math/Vector2.hh>
+#include <gz/math/Triangle.hh>
+#include <gz/math/Vector2.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Triangle3.i
+++ b/src/ruby/Triangle3.i
@@ -17,12 +17,12 @@
 
 %module triangle3
 %{
-#include <ignition/math/config.hh>
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/Line3.hh>
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/Line3.hh>
 #include <set>
-#include <ignition/math/Triangle3.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Triangle3.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Vector2.i
+++ b/src/ruby/Vector2.i
@@ -23,7 +23,7 @@
 
 %module vector2
 %{
-#include <ignition/math/Vector2.hh>
+#include <gz/math/Vector2.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Vector3.i
+++ b/src/ruby/Vector3.i
@@ -23,7 +23,7 @@
 
 %module vector3
 %{
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 namespace ignition

--- a/src/ruby/Vector3Stats.i
+++ b/src/ruby/Vector3Stats.i
@@ -17,10 +17,10 @@
 
 %module vector3stats
 %{
-#include <ignition/math/Helpers.hh>
-#include <ignition/math/SignalStats.hh>
-#include <ignition/math/Vector3.hh>
-#include <ignition/math/Vector3Stats.hh>
+#include <gz/math/Helpers.hh>
+#include <gz/math/SignalStats.hh>
+#include <gz/math/Vector3.hh>
+#include <gz/math/Vector3Stats.hh>
 %}
 
 %include "std_string.i"

--- a/src/ruby/Vector4.i
+++ b/src/ruby/Vector4.i
@@ -23,7 +23,7 @@
 
 %module vector4
 %{
-#include <ignition/math/Vector4.hh>
+#include <gz/math/Vector4.hh>
 %}
 
 namespace ignition

--- a/tutorials/cppgetstarted.md
+++ b/tutorials/cppgetstarted.md
@@ -24,7 +24,7 @@ For this example, we'll take the short and easy approach.
 At this point your main file should look like
 
 ```{.cpp}
-#include <ignition/math.hh>
+#include <gz/math.hh>
 
 int main()
 {
@@ -38,7 +38,7 @@ ignition::math::Vector3d type which is a typedef of `Vector3<double>`. The resul
 addition will be a main file similar to the following.
 
 ```{.cpp}
-#include <ignition/math.hh>
+#include <gz/math.hh>
 
 int main()
 {
@@ -53,7 +53,7 @@ Finally, we can compute the distance between `point1` and `point2` using the
 ignition::math::Vector3::Distance() function and output the distance value.
 
 ```{.cpp}
-#include <ignition/math.hh>
+#include <gz/math.hh>
 
 int main()
 {


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/711, follow-up to https://github.com/gazebosim/gz-math/pull/413 and #419.

## Summary

The ignition headers have been migrated to `include/gz/`, and this converts the remaining `#include <ignition/*>` statements to `#include <gz/*>`. I split the changes into multiple commits to break it up a bit since there are many changes.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
