### PR TITLE
Pose3: deprecate - and -= operators

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -33,6 +33,11 @@ release will remove the deprecated code.
     + The addition operators `+` and `+=` are deprecated in favor of multiplication
       operators `*` and `*=`, though the order of operands is reversed
       (A + B = B * A).
+    + The unitary negation operator `-` is deprecated in favor of the
+      `Inverse()` method.
+    + The subtraction operators `-` and `-=` are deprecated in favor of multiplication
+      by an inverse, though the order of operands is reversed
+      (A - B = B.Inverse() * A).
 
 1. **Quaternion.hh**
     + ***Deprecation:*** public: void Axis(T, T, T, T)

--- a/include/gz/math/Pose3.hh
+++ b/include/gz/math/Pose3.hh
@@ -210,9 +210,9 @@ namespace gz
       /// A is the transform from O to P in frame O
       /// then -A is transform from P to O specified in frame P
       /// \return The resulting pose.
-      public: inline Pose3<T> operator-() const
+      public: GZ_DEPRECATED(7) Pose3<T> operator-() const
       {
-        return Pose3<T>() - *this;
+        return this->Inverse();
       }
 
       /// \brief Subtraction operator.
@@ -221,7 +221,7 @@ namespace gz
       /// B - A is the transform from P to Q in frame P
       /// \param[in] _pose Pose3<T> to subtract from this one.
       /// \return The resulting pose.
-      public: inline Pose3<T> operator-(const Pose3<T> &_pose) const
+      public: GZ_DEPRECATED(7) Pose3<T> operator-(const Pose3<T> &_pose) const
       {
         return Pose3<T>(this->CoordPositionSub(_pose),
           this->CoordRotationSub(_pose.q));
@@ -231,7 +231,8 @@ namespace gz
       /// \param[in] _pose Pose3<T> to subtract from this one
       /// \sa operator-(const Pose3<T> &_pose) const.
       /// \return The resulting pose
-      public: const Pose3<T> &operator-=(const Pose3<T> &_pose)
+      public: GZ_DEPRECATED(7) const Pose3<T> &
+              operator-=(const Pose3<T> &_pose)
       {
         this->p = this->CoordPositionSub(_pose);
         this->q = this->CoordRotationSub(_pose.q);

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -92,14 +92,21 @@ TEST(PoseTest, Pose)
     // then -A is transform from P to O specified in frame P
     math::Pose3d A(math::Vector3d(1, 0, 0),
         math::Quaterniond(0, 0, IGN_PI/4.0));
-    EXPECT_TRUE(math::equal((math::Pose3d() - A).Pos().X(),      -1.0/sqrt(2)));
-    EXPECT_TRUE(math::equal((math::Pose3d() - A).Pos().Y(),       1.0/sqrt(2)));
-    EXPECT_TRUE(math::equal((math::Pose3d() - A).Pos().Z(),               0.0));
-    EXPECT_TRUE(math::equal((math::Pose3d() - A).Rot().Euler().X(),  0.0));
-    EXPECT_TRUE(math::equal((math::Pose3d() - A).Rot().Euler().Y(),  0.0));
-    EXPECT_TRUE(
-        math::equal((math::Pose3d() - A).Rot().Euler().Z(), -IGN_PI/4));
+    EXPECT_TRUE(math::equal(
+        (A.Inverse() * math::Pose3d()).Pos().X(),      -1.0/sqrt(2)));
+    EXPECT_TRUE(math::equal(
+        (A.Inverse() * math::Pose3d()).Pos().Y(),       1.0/sqrt(2)));
+    EXPECT_TRUE(math::equal(
+        (A.Inverse() * math::Pose3d()).Pos().Z(),               0.0));
+    EXPECT_TRUE(math::equal(
+        (A.Inverse() * math::Pose3d()).Rot().Euler().X(),  0.0));
+    EXPECT_TRUE(math::equal(
+        (A.Inverse() * math::Pose3d()).Rot().Euler().Y(),  0.0));
+    EXPECT_TRUE(math::equal(
+        (A.Inverse() * math::Pose3d()).Rot().Euler().Z(), -IGN_PI/4));
 
+    IGN_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+    // Coverage for unitary - operator
     // test negation operator
     EXPECT_TRUE(math::equal((-A).Pos().X(),      -1.0/sqrt(2)));
     EXPECT_TRUE(math::equal((-A).Pos().Y(),       1.0/sqrt(2)));
@@ -107,6 +114,7 @@ TEST(PoseTest, Pose)
     EXPECT_TRUE(math::equal((-A).Rot().Euler().X(),  0.0));
     EXPECT_TRUE(math::equal((-A).Rot().Euler().Y(),  0.0));
     EXPECT_TRUE(math::equal((-A).Rot().Euler().Z(), -IGN_PI/4.0));
+    IGN_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
   }
   {
     // If:
@@ -117,12 +125,22 @@ TEST(PoseTest, Pose)
         math::Quaterniond(0, 0, IGN_PI/4.0));
     math::Pose3d B(math::Vector3d(1, 1, 0),
         math::Quaterniond(0, 0, IGN_PI/2.0));
-    EXPECT_TRUE(math::equal((B - A).Pos().X(),       1.0/sqrt(2)));
-    EXPECT_TRUE(math::equal((B - A).Pos().Y(),       1.0/sqrt(2)));
-    EXPECT_TRUE(math::equal((B - A).Pos().Z(),               0.0));
-    EXPECT_TRUE(math::equal((B - A).Rot().Euler().X(),  0.0));
-    EXPECT_TRUE(math::equal((B - A).Rot().Euler().Y(),  0.0));
-    EXPECT_TRUE(math::equal((B - A).Rot().Euler().Z(), IGN_PI/4.0));
+    EXPECT_TRUE(math::equal((A.Inverse() * B).Pos().X(),       1.0/sqrt(2)));
+    EXPECT_TRUE(math::equal((A.Inverse() * B).Pos().Y(),       1.0/sqrt(2)));
+    EXPECT_TRUE(math::equal((A.Inverse() * B).Pos().Z(),               0.0));
+    EXPECT_TRUE(math::equal((A.Inverse() * B).Rot().Euler().X(),  0.0));
+    EXPECT_TRUE(math::equal((A.Inverse() * B).Rot().Euler().Y(),  0.0));
+    EXPECT_TRUE(math::equal((A.Inverse() * B).Rot().Euler().Z(), IGN_PI/4.0));
+
+    IGN_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+    // Coverage for - operator
+    EXPECT_EQ(A.Inverse() * B, B - A);
+
+    // Coverage for -= operator
+    math::Pose3d C(B);
+    C -= A;
+    EXPECT_EQ(C, A.Inverse() * B);
+    IGN_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
   }
   {
     math::Pose3d pose;
@@ -155,7 +173,7 @@ TEST(PoseTest, Pose)
   EXPECT_TRUE(pose ==
       math::Pose3d(11.314, 16.0487, 15.2559, 1.49463, 0.184295, 2.13932));
 
-  pose -= math::Pose3d(pose);
+  pose = pose.Inverse() * pose;
   EXPECT_TRUE(pose ==
       math::Pose3d(0, 0, 0, 0, 0, 0));
 


### PR DESCRIPTION
# 🎉 New feature

Part of #60.

## Summary

As noted in gz-math#60, there are concerns about the pose subtraction operator. Given that it is equivalent to multiplying by an inverse (albeit with reversed order `A - B = B.Inverse() * A`), this deprecates the unitary negation operator `-` and the subtraction operators `-` and `-=`.

This is a draft PR until all usage of the deprecated behavior has been replaced in downstream repositories.

## Test it

Run `UNIT_Pose3_TEST`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
