### PR TITLE
Add MatrixX class

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,6 +15,9 @@ target_link_libraries(diff_drive_odometry ignition-math${IGN_MATH_VER}::ignition
 add_executable(gauss_markov_process gauss_markov_process_example.cc)
 target_link_libraries(gauss_markov_process ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 
+add_executable(matrixx_example matrixx_example.cc)
+target_link_libraries(matrixx_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
+
 add_executable(vector2_example vector2_example.cc)
 target_link_libraries(vector2_example ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER})
 

--- a/examples/matrixx_example.cc
+++ b/examples/matrixx_example.cc
@@ -19,21 +19,21 @@
 
 int main(int argc, char **argv)
 {
-  ignition::math::MatrixX<double, 2, 3> matd23A(
+  ignition::math::MatrixXd<2, 3> matA(
       0.1, 0.2, 0.3,
       0.4, 0.5, 0.6);
+  std::cout << "Matrix A: " << matA << std::endl;
 
-  ignition::math::MatrixX<double, 2, 3> matd23B(
+  ignition::math::MatrixXd<2, 3> matB(
       1.1, 1.2, 1.3,
       1.4, 1.5, 1.6);
+  std::cout << "Matrix B: " << matB << std::endl;
 
-  auto matSum = matd23A + matd23B;
+  auto matSum = matA + matB;
+  std::cout << "A + B sum: " << matSum << std::endl;
 
-  std::cout << matd23A << std::endl;
-
-  std::cout << matd23B << std::endl;
-
-  std::cout << matSum << std::endl;
+  auto matATrans = matA.Transposed();
+  std::cout << "A transposed: " << matATrans << std::endl;
 
   return 0;
 }

--- a/examples/matrixx_example.cc
+++ b/examples/matrixx_example.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <iostream>
+#include <ignition/math/MatrixX.hh>
+
+int main(int argc, char **argv)
+{
+  ignition::math::MatrixX<double, 2, 3> matd23A(
+      0.1, 0.2, 0.3,
+      0.4, 0.5, 0.6);
+
+  ignition::math::MatrixX<double, 2, 3> matd23B(
+      1.1, 1.2, 1.3,
+      1.4, 1.5, 1.6);
+
+  auto matSum = matd23A + matd23B;
+
+  std::cout << matd23A << std::endl;
+
+  std::cout << matd23B << std::endl;
+
+  std::cout << matSum << std::endl;
+
+  return 0;
+}

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -35,7 +35,8 @@ namespace ignition
     /// \tparam RowCount Number of rows in the matrix, must be higher than zero.
     /// \tparam ColCount Number of columns in the matrix, must be higher than
     /// zero.
-    template<typename Precision, std::size_t RowCount, std::size_t ColCount = RowCount>
+    template<typename Precision, std::size_t RowCount,
+        std::size_t ColCount = RowCount>
     class MatrixX
     {
       /// \brief Constructor
@@ -207,7 +208,8 @@ namespace ignition
       /// \param[in] _m Matrix3 to test
       /// \return true if the 2 matrices are equal (using the tolerance 1e-6),
       ///  false otherwise
-      public: bool operator==(const MatrixX<Precision, RowCount, ColCount> &_m) const
+      public: bool operator==(const MatrixX<Precision, RowCount, ColCount> &_m)
+          const
       {
         return this->Equal(_m, static_cast<Precision>(1e-6));
       }
@@ -215,7 +217,8 @@ namespace ignition
       /// \brief Inequality test operator
       /// \param[in] _m Matrix6<T> to test
       /// \return True if not equal (using the default tolerance of 1e-6)
-      public: bool operator!=(const MatrixX<Precision, RowCount, ColCount> &_m) const
+      public: bool operator!=(const MatrixX<Precision, RowCount, ColCount> &_m)
+          const
       {
         return !(*this == _m);
       }
@@ -276,7 +279,8 @@ namespace ignition
       }
 
       /// \brief The matrix
-      private: std::array<std::array<Precision, ColCount>, RowCount> data = {{}};
+      private: std::array<std::array<Precision, ColCount>, RowCount> data =
+          {{}};
    };
 
   template <std::size_t RowCount, std::size_t ColCount = RowCount>

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_MATH_MATRIXX_HH_
+#define GZ_MATH_MATRIXX_HH_
+
+#include <cassert>
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/config.hh>
+
+namespace ignition
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+    //
+    /// \class MatrixX MatrixX.hh ignition/math/MatrixX.hh
+    /// \brief A matrix with any given size.
+    template<typename Precision, std::size_t Rows, std::size_t Columns>
+    class MatrixX
+    {
+      /// \brief Constructor
+      public: MatrixX()
+      {
+        static_assert(Rows > 0 && Columns > 0,
+            "Matrix can't have zero rows or columns.");
+
+        for (std::size_t row = 0; row < Rows; ++row)
+        {
+          for (std::size_t col = 0; col < Columns; ++col)
+          {
+            this->data[row][col] = static_cast<Precision>(0);
+          }
+        }
+      }
+
+      /// \brief Copy constructor
+      /// \param _m Matrix to copy
+      public: MatrixX(const MatrixX<Precision, Rows, Columns> &_m)
+      {
+        this->data = _m.data;
+      }
+
+      /// \brief Move constructor
+      /// \param _m Matrix to move
+      public: MatrixX(const MatrixX<Precision, Rows, Columns> &&_m)
+      {
+        this->data = std::move(_m.data);
+      }
+
+      /// \brief Constructor
+      /// \param[in] _values Values to fill matrix
+      public:
+      template<class ... Values>
+      MatrixX(Values... _values)
+      {
+        static_assert(Rows > 0 && Columns > 0,
+            "Matrix can't have zero rows or columns.");
+        static_assert(Rows * Columns == sizeof...(_values),
+            "Wrong number of values provided.");
+        this->Set(std::forward<Values>(_values)...);
+      }
+
+      /// \brief Destructor
+      public: virtual ~MatrixX() {};
+
+      /// \brief Change the values
+      /// \param[in] _values Values to set.
+      public:
+      template<class ... Values>
+      void Set(Values... _values)
+      {
+        static_assert(Rows * Columns == sizeof...(_values),
+            "Wrong number of values provided.");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
+        this->data = {std::forward<Values>(_values)...};
+#pragma clang diagnostic pop
+      }
+
+      /// \brief Change value at an index.
+      /// \param[in] _row
+      /// \param[in] _col
+      /// \param[in] _value
+      public: void SetElement(std::size_t _row, std::size_t _col,
+          Precision _value)
+      {
+        this->Clamp(_row, _col, _row, _col);
+        this->data.at(_row).at(_col) = _value;
+      }
+
+      /// \brief Return the transpose of this matrix
+      /// \return Transpose of this matrix.
+      public: MatrixX<Precision, Columns, Rows> Transposed() const
+      {
+        MatrixX<Precision, Columns, Rows> result;
+        for (std::size_t row = 0; row < Rows; ++row)
+        {
+          for (std::size_t col = 0; col < Columns; ++col)
+          {
+            assert(row < Rows);
+            assert(col < Columns);
+            result.SetElement(col, row, this->data[row][col]);
+          }
+        }
+        return result;
+      }
+
+      /// \brief Equal operator. this = _mat
+      /// \param _mat Incoming matrix
+      /// \return itself
+      public: MatrixX<Precision, Rows, Columns> &operator=(
+          const MatrixX<Precision, Rows, Columns> &_mat)
+      {
+        this->data = _mat.data;
+        return *this;
+      }
+
+      /// \brief Addition operator.
+      /// \param[in] _m2 Matrix to sum with.
+      /// \return A new matrix with the sum.
+      public: MatrixX<Precision, Rows, Columns> operator+(
+          const MatrixX<Precision, Rows, Columns> &_m2) const
+      {
+        MatrixX<Precision, Rows, Columns> result;
+        for (std::size_t row = 0; row < Rows; ++row)
+        {
+          for (std::size_t col = 0; col < Columns; ++col)
+          {
+            result.SetElement(row, col, this->data[row][col] + _m2(row, col));
+          }
+        }
+        return result;
+      }
+
+      /// \brief Get the value at the specified row, column index
+      /// \param[in] _row the row index. Index values are clamped to a
+      /// range of [0, Rows].
+      /// \param[in] _col The column index. Index values are clamped to a
+      /// range of [0, Columns].
+      /// \return The value at the specified index
+      public: Precision operator()(std::size_t _row, std::size_t _col) const
+      {
+        this->Clamp(_row, _col, _row, _col);
+        assert(_row < Rows);
+        assert(_col < Columns);
+        return this->data.at(_row).at(_col);
+      }
+
+      /// \brief Equality test with tolerance.
+      /// \param[in] _m the matrix to compare to
+      /// \param[in] _tol equality tolerance.
+      /// \return true if the elements of the matrices are equal within
+      /// the tolerence specified by _tol.
+      public: bool Equal(const MatrixX<Precision, Rows, Columns> &_m,
+          const Precision &_tol = static_cast<Precision>(1e-6)) const
+      {
+        for (std::size_t row = 0; row < Rows; ++row)
+        {
+          for (std::size_t col = 0; col < Columns; ++col)
+          {
+            assert(row < Rows);
+            assert(col < Columns);
+            if (!equal<Precision>(this->data[row][col], _m(row, col), _tol))
+              return false;
+          }
+        }
+        return true;
+      }
+
+      /// \brief Equality operator
+      /// \param[in] _m Matrix3 to test
+      /// \return true if the 2 matrices are equal (using the tolerance 1e-6),
+      ///  false otherwise
+      public: bool operator==(const MatrixX<Precision, Rows, Columns> &_m) const
+      {
+        return this->Equal(_m, static_cast<Precision>(1e-6));
+      }
+
+      /// \brief Inequality test operator
+      /// \param[in] _m Matrix6<T> to test
+      /// \return True if not equal (using the default tolerance of 1e-6)
+      public: bool operator!=(const MatrixX<Precision, Rows, Columns> &_m) const
+      {
+        return !(*this == _m);
+      }
+
+      /// \brief Stream insertion operator
+      /// \param _out output stream
+      /// \param _m Matrix to output
+      /// \return the stream
+      public: friend std::ostream &operator<<(std::ostream &_out,
+          const MatrixX<Precision, Rows, Columns> &_m)
+      {
+        for (std::size_t row = 0; row < Rows; ++row)
+        {
+          for (std::size_t col = 0; col < Columns; ++col)
+          {
+             _out << precision(_m(row, col), 6);
+             if (!(row == (Rows - 1) && col == (Columns - 1)))
+               _out << " ";
+          }
+        }
+        return _out;
+      }
+
+      /// \brief Stream extraction operator
+      /// \param _out output stream
+      /// \param _m Matrix to output
+      /// \return the stream
+      public: friend std::istream &operator>>(std::istream &_in,
+          MatrixX<Precision, Rows, Columns> &_m)
+      {
+        // Skip white spaces
+        _in.setf(std::ios_base::skipws);
+        for (std::size_t row = 0; row < Rows; ++row)
+        {
+          for (std::size_t col = 0; col < Columns; ++col)
+          {
+            Precision temp;
+            _in >> temp;
+            if (!_in.fail())
+            {
+              _m.data[row][col] = temp;
+            }
+          }
+        }
+        return _in;
+      }
+
+      private: void Clamp(std::size_t _inRow, std::size_t _inCol,
+          std::size_t &_outRow, std::size_t &_outCol) const
+      {
+        _outRow = clamp(_inRow, IGN_ZERO_SIZE_T, Rows-1);
+        _outCol = clamp(_inCol, IGN_ZERO_SIZE_T, Columns-1);;
+        assert(_outRow < Rows);
+        assert(_outCol < Columns);
+      }
+
+      /// \brief The matrix
+      private: std::array<std::array<Precision, Columns>, Rows> data = {{}};
+   };
+
+  template <std::size_t Rows, std::size_t Columns>
+  using MatrixXi = MatrixX<int, Rows, Columns>;
+
+  template <std::size_t Rows, std::size_t Columns>
+  using MatrixXd = MatrixX<double, Rows, Columns>;
+
+  template <std::size_t Rows, std::size_t Columns>
+  using MatrixXf = MatrixX<float, Rows, Columns>;
+  }
+  }
+}
+#endif

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -31,21 +31,21 @@ namespace ignition
     /// \class MatrixX MatrixX.hh ignition/math/MatrixX.hh
     /// \brief A matrix that can have any given size.
     /// \tparam Precision Precision such as int, double or float.
-    /// \tparam Rows Number of rows in the matrix, must be higher than zero.
-    /// \tparam Columns Number of columns in the matrix, must be higher than
+    /// \tparam RowCount Number of rows in the matrix, must be higher than zero.
+    /// \tparam ColCount Number of columns in the matrix, must be higher than
     /// zero.
-    template<typename Precision, std::size_t Rows, std::size_t Columns>
+    template<typename Precision, std::size_t RowCount, std::size_t ColCount = RowCount>
     class MatrixX
     {
       /// \brief Constructor
       public: MatrixX()
       {
-        static_assert(Rows > 0 && Columns > 0,
+        static_assert(RowCount > 0 && ColCount > 0,
             "Matrix can't have zero rows or columns.");
 
-        for (std::size_t row = 0; row < Rows; ++row)
+        for (std::size_t row = 0; row < RowCount; ++row)
         {
-          for (std::size_t col = 0; col < Columns; ++col)
+          for (std::size_t col = 0; col < ColCount; ++col)
           {
             this->data[row][col] = static_cast<Precision>(0);
           }
@@ -54,28 +54,28 @@ namespace ignition
 
       /// \brief Copy constructor
       /// \param _m Matrix to copy
-      public: MatrixX(const MatrixX<Precision, Rows, Columns> &_m)
+      public: MatrixX(const MatrixX<Precision, RowCount, ColCount> &_m)
       {
         this->data = _m.data;
       }
 
       /// \brief Move constructor
       /// \param _m Matrix to move
-      public: MatrixX(const MatrixX<Precision, Rows, Columns> &&_m)
+      public: MatrixX(const MatrixX<Precision, RowCount, ColCount> &&_m)
       {
         this->data = std::move(_m.data);
       }
 
       /// \brief Constructor
       /// \param[in] _values Values to fill matrix. The total number of passed
-      /// values must be equal to Rows * Columns.
+      /// values must be equal to RowCount * ColCount.
       public:
       template<class ... Values>
       MatrixX(Values... _values)
       {
-        static_assert(Rows > 0 && Columns > 0,
+        static_assert(RowCount > 0 && ColCount > 0,
             "Matrix can't have zero rows or columns.");
-        static_assert(Rows * Columns == sizeof...(_values),
+        static_assert(RowCount * ColCount == sizeof...(_values),
             "Wrong number of values provided.");
         this->Set(std::forward<Values>(_values)...);
       }
@@ -83,14 +83,28 @@ namespace ignition
       /// \brief Destructor
       public: virtual ~MatrixX() {};
 
+      /// \brief Get the number of rows in this matrix.
+      /// \return The number of rows.
+      public: inline std::size_t Rows() const
+      {
+        return RowCount;
+      }
+
+      /// \brief Get the number of columns in this matrix.
+      /// \return The number of columns.
+      public: inline std::size_t Columns() const
+      {
+        return ColCount;
+      }
+
       /// \brief Set new values for the matrix.
       /// \param[in] _values Values to fill matrix. The total number of passed
-      /// values must be equal to Rows * Columns.
+      /// values must be equal to RowCount * ColCount.
       public:
       template<class ... Values>
       void Set(Values... _values)
       {
-        static_assert(Rows * Columns == sizeof...(_values),
+        static_assert(RowCount * ColCount == sizeof...(_values),
             "Wrong number of values provided.");
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-braces"
@@ -99,8 +113,8 @@ namespace ignition
       }
 
       /// \brief Change value of an element at a given row and column.
-      /// \param[in] _row Row of element, must be < Rows
-      /// \param[in] _col Column of element, must be < Columns
+      /// \param[in] _row Row of element, must be < RowCount
+      /// \param[in] _col Column of element, must be < ColCount
       /// \param[in] _value New value
       public: void SetElement(std::size_t _row, std::size_t _col,
           Precision _value)
@@ -111,15 +125,15 @@ namespace ignition
 
       /// \brief Return the transpose of this matrix
       /// \return Transpose of this matrix.
-      public: MatrixX<Precision, Columns, Rows> Transposed() const
+      public: MatrixX<Precision, ColCount, RowCount> Transposed() const
       {
-        MatrixX<Precision, Columns, Rows> result;
-        for (std::size_t row = 0; row < Rows; ++row)
+        MatrixX<Precision, ColCount, RowCount> result;
+        for (std::size_t row = 0; row < RowCount; ++row)
         {
-          for (std::size_t col = 0; col < Columns; ++col)
+          for (std::size_t col = 0; col < ColCount; ++col)
           {
-            assert(row < Rows);
-            assert(col < Columns);
+            assert(row < RowCount);
+            assert(col < ColCount);
             result.SetElement(col, row, this->data[row][col]);
           }
         }
@@ -129,8 +143,8 @@ namespace ignition
       /// \brief Assignment operator.
       /// \param _mat Incoming matrix
       /// \return This matrix
-      public: MatrixX<Precision, Rows, Columns> &operator=(
-          const MatrixX<Precision, Rows, Columns> &_mat)
+      public: MatrixX<Precision, RowCount, ColCount> &operator=(
+          const MatrixX<Precision, RowCount, ColCount> &_mat)
       {
         this->data = _mat.data;
         return *this;
@@ -139,13 +153,13 @@ namespace ignition
       /// \brief Addition operator.
       /// \param[in] _m2 Matrix to sum with.
       /// \return A new matrix with the sum.
-      public: MatrixX<Precision, Rows, Columns> operator+(
-          const MatrixX<Precision, Rows, Columns> &_m2) const
+      public: MatrixX<Precision, RowCount, ColCount> operator+(
+          const MatrixX<Precision, RowCount, ColCount> &_m2) const
       {
-        MatrixX<Precision, Rows, Columns> result;
-        for (std::size_t row = 0; row < Rows; ++row)
+        MatrixX<Precision, RowCount, ColCount> result;
+        for (std::size_t row = 0; row < RowCount; ++row)
         {
-          for (std::size_t col = 0; col < Columns; ++col)
+          for (std::size_t col = 0; col < ColCount; ++col)
           {
             result.SetElement(row, col, this->data[row][col] + _m2(row, col));
           }
@@ -155,15 +169,15 @@ namespace ignition
 
       /// \brief Get the value at the specified row, column index
       /// \param[in] _row the row index. Index values are clamped to a
-      /// range of [0, Rows].
+      /// range of [0, RowCount].
       /// \param[in] _col The column index. Index values are clamped to a
-      /// range of [0, Columns].
+      /// range of [0, ColCount].
       /// \return The value at the specified index
       public: Precision operator()(std::size_t _row, std::size_t _col) const
       {
         this->Clamp(_row, _col);
-        assert(_row < Rows);
-        assert(_col < Columns);
+        assert(_row < RowCount);
+        assert(_col < ColCount);
         return this->data.at(_row).at(_col);
       }
 
@@ -172,15 +186,15 @@ namespace ignition
       /// \param[in] _tol equality tolerance.
       /// \return true if the elements of the matrices are equal within
       /// the tolerence specified by _tol.
-      public: bool Equal(const MatrixX<Precision, Rows, Columns> &_m,
+      public: bool Equal(const MatrixX<Precision, RowCount, ColCount> &_m,
           const Precision &_tol = static_cast<Precision>(1e-6)) const
       {
-        for (std::size_t row = 0; row < Rows; ++row)
+        for (std::size_t row = 0; row < RowCount; ++row)
         {
-          for (std::size_t col = 0; col < Columns; ++col)
+          for (std::size_t col = 0; col < ColCount; ++col)
           {
-            assert(row < Rows);
-            assert(col < Columns);
+            assert(row < RowCount);
+            assert(col < ColCount);
             if (!equal<Precision>(this->data[row][col], _m(row, col), _tol))
               return false;
           }
@@ -192,7 +206,7 @@ namespace ignition
       /// \param[in] _m Matrix3 to test
       /// \return true if the 2 matrices are equal (using the tolerance 1e-6),
       ///  false otherwise
-      public: bool operator==(const MatrixX<Precision, Rows, Columns> &_m) const
+      public: bool operator==(const MatrixX<Precision, RowCount, ColCount> &_m) const
       {
         return this->Equal(_m, static_cast<Precision>(1e-6));
       }
@@ -200,7 +214,7 @@ namespace ignition
       /// \brief Inequality test operator
       /// \param[in] _m Matrix6<T> to test
       /// \return True if not equal (using the default tolerance of 1e-6)
-      public: bool operator!=(const MatrixX<Precision, Rows, Columns> &_m) const
+      public: bool operator!=(const MatrixX<Precision, RowCount, ColCount> &_m) const
       {
         return !(*this == _m);
       }
@@ -210,14 +224,14 @@ namespace ignition
       /// \param _m Matrix to output
       /// \return the stream
       public: friend std::ostream &operator<<(std::ostream &_out,
-          const MatrixX<Precision, Rows, Columns> &_m)
+          const MatrixX<Precision, RowCount, ColCount> &_m)
       {
-        for (std::size_t row = 0; row < Rows; ++row)
+        for (std::size_t row = 0; row < RowCount; ++row)
         {
-          for (std::size_t col = 0; col < Columns; ++col)
+          for (std::size_t col = 0; col < ColCount; ++col)
           {
              _out << precision(_m(row, col), 6);
-             if (!(row == (Rows - 1) && col == (Columns - 1)))
+             if (!(row == (RowCount - 1) && col == (ColCount - 1)))
                _out << " ";
           }
         }
@@ -229,13 +243,13 @@ namespace ignition
       /// \param _m Matrix to output
       /// \return the stream
       public: friend std::istream &operator>>(std::istream &_in,
-          MatrixX<Precision, Rows, Columns> &_m)
+          MatrixX<Precision, RowCount, ColCount> &_m)
       {
         // Skip white spaces
         _in.setf(std::ios_base::skipws);
-        for (std::size_t row = 0; row < Rows; ++row)
+        for (std::size_t row = 0; row < RowCount; ++row)
         {
-          for (std::size_t col = 0; col < Columns; ++col)
+          for (std::size_t col = 0; col < ColCount; ++col)
           {
             Precision temp;
             _in >> temp;
@@ -254,24 +268,24 @@ namespace ignition
       /// \param[in, out] _col Column value to clamp.
       private: void Clamp(std::size_t &_row, std::size_t &_col) const
       {
-        _row = clamp(_row, IGN_ZERO_SIZE_T, Rows-1);
-        _col = clamp(_col, IGN_ZERO_SIZE_T, Columns-1);;
-        assert(_row < Rows);
-        assert(_col < Columns);
+        _row = clamp(_row, IGN_ZERO_SIZE_T, RowCount-1);
+        _col = clamp(_col, IGN_ZERO_SIZE_T, ColCount-1);;
+        assert(_row < RowCount);
+        assert(_col < ColCount);
       }
 
       /// \brief The matrix
-      private: std::array<std::array<Precision, Columns>, Rows> data = {{}};
+      private: std::array<std::array<Precision, ColCount>, RowCount> data = {{}};
    };
 
-  template <std::size_t Rows, std::size_t Columns>
-  using MatrixXi = MatrixX<int, Rows, Columns>;
+  template <std::size_t RowCount, std::size_t ColCount = RowCount>
+  using MatrixXi = MatrixX<int, RowCount, ColCount>;
 
-  template <std::size_t Rows, std::size_t Columns>
-  using MatrixXd = MatrixX<double, Rows, Columns>;
+  template <std::size_t RowCount, std::size_t ColCount = RowCount>
+  using MatrixXd = MatrixX<double, RowCount, ColCount>;
 
-  template <std::size_t Rows, std::size_t Columns>
-  using MatrixXf = MatrixX<float, Rows, Columns>;
+  template <std::size_t RowCount, std::size_t ColCount = RowCount>
+  using MatrixXf = MatrixX<float, RowCount, ColCount>;
   }
   }
 }

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_MATH_MATRIXX_HH_
 #define GZ_MATH_MATRIXX_HH_
 
+#include <array>
 #include <cassert>
 #include <utility>
 #include <ignition/math/Helpers.hh>

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -18,6 +18,7 @@
 #define GZ_MATH_MATRIXX_HH_
 
 #include <cassert>
+#include <utility>
 #include <ignition/math/Helpers.hh>
 #include <ignition/math/config.hh>
 
@@ -71,7 +72,7 @@ namespace ignition
       /// values must be equal to RowCount * ColCount.
       public:
       template<class ... Values>
-      MatrixX(Values... _values)
+      explicit MatrixX(Values... _values)
       {
         static_assert(RowCount > 0 && ColCount > 0,
             "Matrix can't have zero rows or columns.");
@@ -81,7 +82,7 @@ namespace ignition
       }
 
       /// \brief Destructor
-      public: virtual ~MatrixX() {};
+      public: virtual ~MatrixX() {}
 
       /// \brief Get the number of rows in this matrix.
       /// \return The number of rows.

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -29,7 +29,11 @@ namespace ignition
     inline namespace IGNITION_MATH_VERSION_NAMESPACE {
     //
     /// \class MatrixX MatrixX.hh ignition/math/MatrixX.hh
-    /// \brief A matrix with any given size.
+    /// \brief A matrix that can have any given size.
+    /// \tparam Precision Precision such as int, double or float.
+    /// \tparam Rows Number of rows in the matrix, must be higher than zero.
+    /// \tparam Columns Number of columns in the matrix, must be higher than
+    /// zero.
     template<typename Precision, std::size_t Rows, std::size_t Columns>
     class MatrixX
     {
@@ -63,7 +67,8 @@ namespace ignition
       }
 
       /// \brief Constructor
-      /// \param[in] _values Values to fill matrix
+      /// \param[in] _values Values to fill matrix. The total number of passed
+      /// values must be equal to Rows * Columns.
       public:
       template<class ... Values>
       MatrixX(Values... _values)
@@ -78,8 +83,9 @@ namespace ignition
       /// \brief Destructor
       public: virtual ~MatrixX() {};
 
-      /// \brief Change the values
-      /// \param[in] _values Values to set.
+      /// \brief Set new values for the matrix.
+      /// \param[in] _values Values to fill matrix. The total number of passed
+      /// values must be equal to Rows * Columns.
       public:
       template<class ... Values>
       void Set(Values... _values)
@@ -92,14 +98,14 @@ namespace ignition
 #pragma clang diagnostic pop
       }
 
-      /// \brief Change value at an index.
-      /// \param[in] _row
-      /// \param[in] _col
-      /// \param[in] _value
+      /// \brief Change value of an element at a given row and column.
+      /// \param[in] _row Row of element, must be < Rows
+      /// \param[in] _col Column of element, must be < Columns
+      /// \param[in] _value New value
       public: void SetElement(std::size_t _row, std::size_t _col,
           Precision _value)
       {
-        this->Clamp(_row, _col, _row, _col);
+        this->Clamp(_row, _col);
         this->data.at(_row).at(_col) = _value;
       }
 
@@ -120,9 +126,9 @@ namespace ignition
         return result;
       }
 
-      /// \brief Equal operator. this = _mat
+      /// \brief Assignment operator.
       /// \param _mat Incoming matrix
-      /// \return itself
+      /// \return This matrix
       public: MatrixX<Precision, Rows, Columns> &operator=(
           const MatrixX<Precision, Rows, Columns> &_mat)
       {
@@ -155,7 +161,7 @@ namespace ignition
       /// \return The value at the specified index
       public: Precision operator()(std::size_t _row, std::size_t _col) const
       {
-        this->Clamp(_row, _col, _row, _col);
+        this->Clamp(_row, _col);
         assert(_row < Rows);
         assert(_col < Columns);
         return this->data.at(_row).at(_col);
@@ -242,13 +248,16 @@ namespace ignition
         return _in;
       }
 
-      private: void Clamp(std::size_t _inRow, std::size_t _inCol,
-          std::size_t &_outRow, std::size_t &_outCol) const
+      /// \brief Helper function to clamp row and column values to fit this
+      /// matrix.
+      /// \param[in, out] _row Row value to clamp.
+      /// \param[in, out] _col Column value to clamp.
+      private: void Clamp(std::size_t &_row, std::size_t &_col) const
       {
-        _outRow = clamp(_inRow, IGN_ZERO_SIZE_T, Rows-1);
-        _outCol = clamp(_inCol, IGN_ZERO_SIZE_T, Columns-1);;
-        assert(_outRow < Rows);
-        assert(_outCol < Columns);
+        _row = clamp(_row, IGN_ZERO_SIZE_T, Rows-1);
+        _col = clamp(_col, IGN_ZERO_SIZE_T, Columns-1);;
+        assert(_row < Rows);
+        assert(_col < Columns);
       }
 
       /// \brief The matrix

--- a/include/ignition/math/MatrixX.hh
+++ b/include/ignition/math/MatrixX.hh
@@ -108,10 +108,14 @@ namespace ignition
       {
         static_assert(RowCount * ColCount == sizeof...(_values),
             "Wrong number of values provided.");
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-braces"
+#if defined(__clang__)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-braces"
+#endif
         this->data = {std::forward<Values>(_values)...};
-#pragma clang diagnostic pop
+#if defined(__clang__)
+  #pragma clang diagnostic pop
+#endif
       }
 
       /// \brief Change value of an element at a given row and column.
@@ -243,7 +247,7 @@ namespace ignition
       }
 
       /// \brief Stream extraction operator
-      /// \param _out output stream
+      /// \param _in Input stream
       /// \param _m Matrix to output
       /// \return the stream
       public: friend std::istream &operator>>(std::istream &_in,

--- a/src/MatrixX_TEST.cc
+++ b/src/MatrixX_TEST.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "ignition/math/MatrixX.hh"
+
+using namespace ignition;
+using namespace math;
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, Construct)
+{
+  // Starts with zeroes
+  MatrixX<int, 3, 1> mati31;
+  for (int i = 0; i < 3; ++i)
+  {
+    EXPECT_EQ(0, mati31(i, 0)) << i;
+  }
+
+  // Initialize with values
+  MatrixX<double, 1, 1> matd11(1.23);
+  EXPECT_DOUBLE_EQ(1.23, matd11(0, 0));
+
+  MatrixXd<6, 6> matd66(
+      0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
+      6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+      12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
+      18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
+      24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
+      30.0, 31.0, 32.0, 33.0, 34.0, 35.0);
+
+  EXPECT_DOUBLE_EQ(matd66(0, 0), 0.0);
+  EXPECT_DOUBLE_EQ(matd66(0, 1), 1.0);
+  EXPECT_DOUBLE_EQ(matd66(0, 2), 2.0);
+  EXPECT_DOUBLE_EQ(matd66(0, 3), 3.0);
+  EXPECT_DOUBLE_EQ(matd66(0, 4), 4.0);
+  EXPECT_DOUBLE_EQ(matd66(0, 5), 5.0);
+  EXPECT_DOUBLE_EQ(matd66(1, 0), 6.0);
+  EXPECT_DOUBLE_EQ(matd66(1, 1), 7.0);
+  EXPECT_DOUBLE_EQ(matd66(1, 2), 8.0);
+  EXPECT_DOUBLE_EQ(matd66(1, 3), 9.0);
+  EXPECT_DOUBLE_EQ(matd66(1, 4), 10.0);
+  EXPECT_DOUBLE_EQ(matd66(1, 5), 11.0);
+  EXPECT_DOUBLE_EQ(matd66(2, 0), 12.0);
+  EXPECT_DOUBLE_EQ(matd66(2, 1), 13.0);
+  EXPECT_DOUBLE_EQ(matd66(2, 2), 14.0);
+  EXPECT_DOUBLE_EQ(matd66(2, 3), 15.0);
+  EXPECT_DOUBLE_EQ(matd66(2, 4), 16.0);
+  EXPECT_DOUBLE_EQ(matd66(2, 5), 17.0);
+  EXPECT_DOUBLE_EQ(matd66(3, 0), 18.0);
+  EXPECT_DOUBLE_EQ(matd66(3, 1), 19.0);
+  EXPECT_DOUBLE_EQ(matd66(3, 2), 20.0);
+  EXPECT_DOUBLE_EQ(matd66(3, 3), 21.0);
+  EXPECT_DOUBLE_EQ(matd66(3, 4), 22.0);
+  EXPECT_DOUBLE_EQ(matd66(3, 5), 23.0);
+  EXPECT_DOUBLE_EQ(matd66(4, 0), 24.0);
+  EXPECT_DOUBLE_EQ(matd66(4, 1), 25.0);
+  EXPECT_DOUBLE_EQ(matd66(4, 2), 26.0);
+  EXPECT_DOUBLE_EQ(matd66(4, 3), 27.0);
+  EXPECT_DOUBLE_EQ(matd66(4, 4), 28.0);
+  EXPECT_DOUBLE_EQ(matd66(4, 5), 29.0);
+  EXPECT_DOUBLE_EQ(matd66(5, 0), 30.0);
+  EXPECT_DOUBLE_EQ(matd66(5, 1), 31.0);
+  EXPECT_DOUBLE_EQ(matd66(5, 2), 32.0);
+  EXPECT_DOUBLE_EQ(matd66(5, 3), 33.0);
+  EXPECT_DOUBLE_EQ(matd66(5, 4), 34.0);
+  EXPECT_DOUBLE_EQ(matd66(5, 5), 35.0);
+  EXPECT_DOUBLE_EQ(matd66(100, 100), 35.0);
+
+  // Copy constructor
+  MatrixX<double, 1, 1> matd11Copy(matd11);
+  EXPECT_DOUBLE_EQ(1.23, matd11Copy(0, 0));
+  EXPECT_DOUBLE_EQ(1.23, matd11(0, 0));
+
+  // Copy assignment
+  MatrixX<double, 1, 1> matd11Copy2;
+  matd11Copy2 = matd11;
+  EXPECT_DOUBLE_EQ(1.23, matd11Copy2(0, 0));
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, CoverageExtra)
+{
+  // getting full destructor coverage
+  auto p = new MatrixXi<3, 5>();
+  EXPECT_NE(p, nullptr);
+  delete p;
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, Addition)
+{
+  MatrixX<double, 2, 3> matd23A(
+      0.1, 0.2, 0.3,
+      0.4, 0.5, 0.6);
+
+  MatrixX<double, 2, 3> matd23B(
+      1.1, 1.2, 1.3,
+      1.4, 1.5, 1.6);
+
+  auto matSum = matd23A + matd23B;
+  EXPECT_DOUBLE_EQ(matSum(0, 0), 1.2);
+  EXPECT_DOUBLE_EQ(matSum(0, 1), 1.4);
+  EXPECT_DOUBLE_EQ(matSum(0, 2), 1.6);
+  EXPECT_DOUBLE_EQ(matSum(1, 0), 1.8);
+  EXPECT_DOUBLE_EQ(matSum(1, 1), 2.0);
+  EXPECT_DOUBLE_EQ(matSum(1, 2), 2.2);
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXTest, NoIndexException)
+{
+  MatrixXf<1, 2> mat;
+  for (int i = 0; i < 6; ++i)
+    for (int j = 0; j < 6; ++j)
+      EXPECT_NO_THROW(mat(i, j));
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, OperatorStreamOut)
+{
+  MatrixX<float, 3, 1> mat(1.1f, 2.2f, 3.3f);
+  std::ostringstream stream;
+  stream << mat;
+  EXPECT_EQ(stream.str(), "1.1 2.2 3.3");
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, OperatorStreamIn)
+{
+  MatrixX<double, 2, 3> matA;
+
+  std::istringstream stream("1 2 3 4 5 6");
+  stream >> matA;
+
+  auto matB = MatrixX<double, 2, 3>(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  EXPECT_EQ(matA, matB);
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, NotEqual)
+{
+  {
+    MatrixX<double, 1, 4> matrix1;
+    MatrixX<double, 1, 4> matrix2;
+    EXPECT_TRUE(matrix1 == matrix2);
+    EXPECT_FALSE(matrix1 != matrix2);
+    EXPECT_TRUE(matrix1.Equal(matrix2));
+  }
+
+  {
+    MatrixX<double, 1, 4> matrix1(1.0, 2.0, 3.0, 4.0);
+    MatrixX<double, 1, 4> matrix2(matrix1);
+
+    EXPECT_TRUE(matrix1 == matrix1);
+    EXPECT_FALSE(matrix1 != matrix1);
+    EXPECT_TRUE(matrix1.Equal(matrix2));
+
+    matrix2.SetElement(0u, 0u, 1.00001);
+    EXPECT_TRUE(matrix1 != matrix2);
+    EXPECT_FALSE(matrix1.Equal(matrix2));
+
+    matrix2.SetElement(0u, 0u, 1.000001);
+    EXPECT_FALSE(matrix1 != matrix2);
+    EXPECT_TRUE(matrix1.Equal(matrix2));
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(MatrixXdTest, Transpose)
+{
+  // Matrix and expected transpose
+  MatrixX<double, 4, 2> mat42(
+      -2.0, 4.0,
+      0.1, 9.0,
+      -7.0, 1.0,
+      0.2, 3.0);
+
+  MatrixX<double, 2, 4> mat24(
+      -2.0, 0.1, -7.0, 0.2,
+      4.0, 9.0, 1.0, 3.0);
+
+  EXPECT_EQ(mat24.Transposed(), mat42);
+  EXPECT_EQ(mat42.Transposed(), mat24);
+}

--- a/src/MatrixX_TEST.cc
+++ b/src/MatrixX_TEST.cc
@@ -23,6 +23,46 @@ using namespace ignition;
 using namespace math;
 
 /////////////////////////////////////////////////
+TEST(MatrixXdTest, Types)
+{
+  MatrixX<int, 1, 2> precisionIntRowCol;
+  EXPECT_EQ(1u, precisionIntRowCol.Rows());
+  EXPECT_EQ(2u, precisionIntRowCol.Columns());
+
+  MatrixX<double, 3, 4> precisionDoubleRowCol;
+  EXPECT_EQ(3u, precisionDoubleRowCol.Rows());
+  EXPECT_EQ(4u, precisionDoubleRowCol.Columns());
+
+  MatrixX<float, 2, 1> precisionFloatRowCol;
+  EXPECT_EQ(2u, precisionFloatRowCol.Rows());
+  EXPECT_EQ(1u, precisionFloatRowCol.Columns());
+
+  MatrixXi<3, 3> intRowCol;
+  EXPECT_EQ(3u, intRowCol.Rows());
+  EXPECT_EQ(3u, intRowCol.Columns());
+
+  MatrixXd<3, 1> doubleRowCol;
+  EXPECT_EQ(3u, doubleRowCol.Rows());
+  EXPECT_EQ(1u, doubleRowCol.Columns());
+
+  MatrixXf<1, 3> floatRowCol;
+  EXPECT_EQ(1u, floatRowCol.Rows());
+  EXPECT_EQ(3u, floatRowCol.Columns());
+
+  MatrixXi<5> intSize;
+  EXPECT_EQ(5u, intSize.Rows());
+  EXPECT_EQ(5u, intSize.Columns());
+
+  MatrixXd<6> doubleSize;
+  EXPECT_EQ(6u, doubleSize.Rows());
+  EXPECT_EQ(6u, doubleSize.Columns());
+
+  MatrixXf<2> floatSize;
+  EXPECT_EQ(2u, floatSize.Rows());
+  EXPECT_EQ(2u, floatSize.Columns());
+}
+
+/////////////////////////////////////////////////
 TEST(MatrixXdTest, Construct)
 {
   // Starts with zeroes


### PR DESCRIPTION
# 🎉 New feature

* Addresses https://github.com/gazebosim/gz-math/issues/144
* Part of https://github.com/gazebosim/gz-sim/issues/1462

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

We're coming for you, Eigen! (Well, that's what a lot of people think about `gz-math`... 😆 )

We need a `Matrix6d` to implement

* https://github.com/gazebosim/gz-sim/issues/1462

Instead of copying the existing `Matrix3` and `Matrix4` classes, I thought it would be useful to implement a matrix class that can have any size. The size is defined at compile time and can't be changed for a given object, so the matrix can't be dynamically resized.

I only implemented very basic functionality, more functions can be added to this class as needed. I think we probably have everything that's needed to implement added mass, but if we don't I can add new functions later.

I experimented with different `std` algorithms to substitute the nested for loops, but they were all too confusing to use with nested `std::array`. I'm open to suggestions though.

### TODO

- [ ] I'd like to get some high-level feedback on this PR and the added APIs before adding Python bindings for this class.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Take a look at the added tests and run the new example.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] ~~Updated migration guide (as needed)~~
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
