### PR TITLE
Suppress warnings

### DIFF
--- a/src/python_pybind11/src/Filter.hh
+++ b/src/python_pybind11/src/Filter.hh
@@ -66,7 +66,7 @@ public:
         PYBIND11_OVERLOAD_PURE(
             const T&,     // Return type (ret_type)
             Filter<T>,    // Parent class (cname)
-            Value         // Name of function in C++ (must match Python name)
+            Value,         // Name of function in C++ (must match Python name)
         );
     }
 };

--- a/src/python_pybind11/src/SignalStats.cc
+++ b/src/python_pybind11/src/SignalStats.cc
@@ -436,7 +436,7 @@ public:
             std::string,                      // Return type (ret_type)
             gz::math::SignalStatistic,  // Parent class (cname)
             // Name of function in C++ (must match Python name) (fn)
-            ShortName
+            ShortName,
         );
     }
     // Trampoline (need one for each virtual function)

--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -53,7 +53,7 @@ if (RUBY_FOUND)
   # Suppress warnings on SWIG-generated files
   target_compile_options(${SWIG_RB_LIB} PRIVATE
     $<$<CXX_COMPILER_ID:GNU>:-Wno-pedantic -Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
-    $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-unused-parameter -Wno-deprecated-declarations>
     $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
   )
   target_include_directories(${SWIG_RB_LIB} SYSTEM PUBLIC ${RUBY_INCLUDE_DIRS})
@@ -86,7 +86,7 @@ if (RUBY_FOUND)
   foreach (test ${ruby_tests})
     add_test(NAME ${test}.rb COMMAND
       ruby -I${FAKE_INSTALL_PREFIX}/lib/ruby/ignition ${CMAKE_SOURCE_DIR}/src/ruby/${test}.rb
-   	  --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${test}rb.xml)
+         --gtest_output=xml:${CMAKE_BINARY_DIR}/test_results/${test}rb.xml)
     set_tests_properties(${test}.rb PROPERTIES
       ENVIRONMENT "${_env_vars}")
   endforeach()

--- a/test/integration/deprecated_TEST.cc
+++ b/test/integration/deprecated_TEST.cc
@@ -27,6 +27,7 @@
 TEST(Deprecated, IgnitionNamespace)
 {
   ignition::math::Angle angle;
+  (void) angle;
 }
 
 #undef SUPPRESS_IGNITION_HEADER_DEPRECATION


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Cleans up a few Jammy/Clang warnings.

* 4826ac9e4e2b56dbe609bb4bff5cb41e1185e4df - There were a few places where there should have been a trailing comma.
* c3b20df8ea708507a9da16a0f77479ec42d3829d
  * Add a (void) to suppress an unused variable check (since we are just looking for compilation here)
  * Remove `-Wno-maybe-uninitialized`, which is not a clang argument (since at least version 5: https://releases.llvm.org/5.0.0/tools/clang/docs/DiagnosticsReference.html) 
  * Adds no deprecated declarations to Ruby, as ruby 3.0.0 and swig spew warnings.  This issue (https://github.com/swig/swig/issues/1689), first indicates it is a swig issue, which then says a ruby issue, which then says a GCC issue.  I'm not using GCC and still seeing it, it seems safe to ignore.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.