### PR TITLE
Fluid added mass / symmetric matrix

### DIFF
--- a/include/gz/math/FluidAddedMass.hh
+++ b/include/gz/math/FluidAddedMass.hh
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_MATH_FLUIDADDEDMASS_HH_
+#define GZ_MATH_FLUIDADDEDMASS_HH_
+
+#include <algorithm>
+#include <array>
+
+#include <gz/math/config.hh>
+#include <gz/math/Helpers.hh>
+
+namespace gz
+{
+  namespace math
+  {
+    // Inline bracket to help doxygen filtering.
+    inline namespace GZ_MATH_VERSION_NAMESPACE {
+    //
+    /// \class FluidAddedMass FluidAddedMass.hh gz/math/FluidAddedMass.hh
+    /// \brief TODO
+    template<typename T>
+    class FluidAddedMass
+    {
+      /// \brief Size of matrix is fixed to 6x6
+      public: static constexpr std::size_t MatrixSize{6};
+
+      /// \brief Size of storage for a 6x6 symmetric matrix is its triangular number, 21
+      public: static constexpr std::size_t StorageSize = (MatrixSize * (MatrixSize + 1)) / 2;
+
+      /// \brief Default Constructor, which inializes the terms to zero.
+      public: FluidAddedMass()
+      {
+        std::fill(std::begin(this->terms), std::end(this->terms),
+            static_cast<T>(0));
+      }
+
+      /// \brief Constructor.
+      /// TODO
+      public: FluidAddedMass(const std::array<T, StorageSize> &_terms)
+      : terms(_terms)
+      {}
+
+      /// \brief Copy constructor.
+      /// \param[in] _m FluidAddedMass element to copy
+      public: FluidAddedMass(const FluidAddedMass<T> &_m) = default;
+
+      /// \brief Destructor.
+      public: ~FluidAddedMass() = default;
+
+      /// \brief TODO
+      public:
+      template<class ... Terms>
+      void SetTerms(Terms... _terms)
+      {
+        static_assert(StorageSize == sizeof...(_terms),
+            "Wrong number of terms provided.");
+        this->terms = {std::forward<Terms>(_terms)...};
+      }
+
+      /// \brief TODO
+      public: const std::array<T, StorageSize> &Terms() const
+      {
+        return this->terms;
+      }
+
+      /// \brief TODO
+      public: void SetTerm(std::size_t _row, std::size_t _col, T _value)
+      {
+        this->terms[this->RowColToIndex(_row, _col)] = _value;
+      }
+
+      /// \brief TODO
+      public: T Term(std::size_t _row, std::size_t _col) const
+      {
+        return this->terms[this->RowColToIndex(_row, _col)];
+      }
+
+      /// \brief TODO
+      public: std::size_t RowColToIndex(std::size_t _row, std::size_t _col) const
+      {
+        auto row = clamp(_row, GZ_ZERO_SIZE_T, this->MatrixSize - 1);
+        auto col = clamp(_col, GZ_ZERO_SIZE_T, this->MatrixSize - 1);;
+
+        if (row <= col)
+           return row * this->MatrixSize - (row - 1) * row / 2 + col - row;
+        else
+           return col * this->MatrixSize - (col - 1) * col / 2 + row - col;
+      }
+
+      /// \brief
+      private: std::array<T, StorageSize> terms;
+    };
+
+    typedef FluidAddedMass<double> FluidAddedMassd;
+    typedef FluidAddedMass<float> FluidAddedMassf;
+    }
+  }
+}
+#endif

--- a/include/gz/math/Inertial.hh
+++ b/include/gz/math/Inertial.hh
@@ -18,6 +18,7 @@
 #define GZ_MATH_INERTIAL_HH_
 
 #include <gz/math/config.hh>
+#include "gz/math/FluidAddedMass.hh"
 #include "gz/math/MassMatrix3.hh"
 #include "gz/math/Pose3.hh"
 
@@ -328,6 +329,9 @@ namespace gz
       /// \brief Pose offset of center of mass reference frame relative
       /// to a base frame.
       private: Pose3<T> pose;
+
+      /// \brief
+      private: FluidAddedMass<T> addedMass;
     };
 
     typedef Inertial<double> Inertiald;


### PR DESCRIPTION
# 🎉 New feature

* Part of https://github.com/gazebosim/gz-sim/issues/1462
* Alternative to https://github.com/gazebosim/gz-math/pull/442

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Based on the feedback on #442, I started implementing a specific class to hold fluid added mass. I stopped halfway through the implementation because various aspects of this didn't feel right to me, so I'm opening this for others to take a look and we have something more concrete to discuss.

I couldn't come up with ways to make the API a bit more semantically specific to added mass, and I don't even know if we want to. Maritime literature usually uses numeric indices to denote these terms within the matrix and AFAICT it is not common to decompose the matrix. It's true that we may need to shift submatrices around to adapt to different conventions, such as swapped rotational and translational components, or even shift things even more if a physics engine doesn't use Z-up. But I feel like this is the kind of thing that we can address with documentation, not APIs.

So my inclination at this point is to go with either:

* The `MatrixX` class in #442 
* This PR, with `FluidAddedMass` renamed to `SymmetricMatrixX` and made general since there isn't anything specific to "6" in the implementation so far.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
