### PR TITLE
SphericalCoordinates: make query methods const

### DIFF
--- a/include/gz/math/SphericalCoordinates.hh
+++ b/include/gz/math/SphericalCoordinates.hh
@@ -199,19 +199,19 @@ namespace gz
 
       /// \brief Get the radius of the surface.
       /// \return radius of the surface in use.
-      public: double SurfaceRadius();
+      public: double SurfaceRadius() const;
 
       /// \brief Get the major axis of the surface.
       /// \return Equatorial axis of the surface in use.
-      public: double SurfaceAxisEquatorial();
+      public: double SurfaceAxisEquatorial() const;
 
       /// \brief Get the minor axis of the surface.
       /// \return Polar axis of the surface in use.
-      public: double SurfaceAxisPolar();
+      public: double SurfaceAxisPolar() const;
 
       /// \brief Get the flattening of the surface.
       /// \return Flattening parameter of the surface in use.
-      public: double SurfaceFlattening();
+      public: double SurfaceFlattening() const;
 
       /// \brief Get reference geodetic latitude.
       /// \return Reference geodetic latitude.

--- a/src/SphericalCoordinates.cc
+++ b/src/SphericalCoordinates.cc
@@ -434,8 +434,10 @@ double SphericalCoordinates::Distance(const gz::math::Angle &_latA,
                                       const gz::math::Angle &_latB,
                                       const gz::math::Angle &_lonB)
 {
+  // LCOV_EXCL_START
   return gz::math::SphericalCoordinates::DistanceWGS84(
       _latA, _lonA, _latB, _lonB);
+  // LCOV_EXCL_STOP
 }
 
 //////////////////////////////////////////////////
@@ -460,25 +462,25 @@ double SphericalCoordinates::DistanceBetweenPoints(
 }
 
 //////////////////////////////////////////////////
-double SphericalCoordinates::SurfaceRadius()
+double SphericalCoordinates::SurfaceRadius() const
 {
   return this->dataPtr->surfaceRadius;
 }
 
 //////////////////////////////////////////////////
-double SphericalCoordinates::SurfaceAxisEquatorial()
+double SphericalCoordinates::SurfaceAxisEquatorial() const
 {
   return this->dataPtr->ellA;
 }
 
 //////////////////////////////////////////////////
-double SphericalCoordinates::SurfaceAxisPolar()
+double SphericalCoordinates::SurfaceAxisPolar() const
 {
   return this->dataPtr->ellB;
 }
 
 //////////////////////////////////////////////////
-double SphericalCoordinates::SurfaceFlattening()
+double SphericalCoordinates::SurfaceFlattening() const
 {
   return this->dataPtr->ellF;
 }


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

# 🦟 Bug fix

## Summary
This PR changes ``SurfaceRadius, AxisEquatorial, AxisPolar, Flattening`` methods to const, similar to other existing methods ``Heading(), LatitudeReference(), etc``.

Also adds comments to exclude deprecated distance function from code coverage.

Follow up to https://github.com/gazebosim/gz-math/pull/434

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸