### PR TITLE
Backport newest appendToStream functions

### DIFF
--- a/include/ignition/math/Helpers.hh
+++ b/include/ignition/math/Helpers.hh
@@ -619,6 +619,31 @@ namespace ignition
       sort2(_a, _b);
     }
 
+    /// \brief Append a number to a stream. Makes sure "-0" is returned as "0".
+    /// \param[out] _out Output stream.
+    /// \param[in] _number Number to append.
+    template<typename T>
+    inline void appendToStream(std::ostream &_out, T _number)
+    {
+      if (std::fpclassify(_number) == FP_ZERO)
+      {
+        _out << 0;
+      }
+      else
+      {
+        _out << _number;
+      }
+    }
+
+    /// \brief Append a number to a stream, specialized for int.
+    /// \param[out] _out Output stream.
+    /// \param[in] _number Number to append.
+    template<>
+    inline void appendToStream(std::ostream &_out, int _number)
+    {
+      _out << _number;
+    }
+
     /// \brief Is this a power of 2?
     /// \param[in] _x the number
     /// \return true if _x is a power of 2, false otherwise

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -970,3 +970,55 @@ TEST(HelpersTest, roundUpMultiple)
   EXPECT_EQ(0, math::roundUpMultiple(0, -2));
   EXPECT_EQ(-2, math::roundUpMultiple(-2, -2));
 }
+
+/////////////////////////////////////////////////
+TEST(HelpersTest, AppendToStream)
+{
+  std::ostringstream out;
+
+  math::appendToStream(out, 0.0f);
+  EXPECT_EQ(out.str(), "0");
+
+  out << " ";
+
+  math::appendToStream(out, 456);
+  EXPECT_EQ(out.str(), "0 456");
+
+  out << " ";
+
+  math::appendToStream(out, 0);
+  EXPECT_EQ(out.str(), "0 456 0");
+
+  out << " ";
+
+  // ref: https://en.cppreference.com/w/cpp/io/manip/setprecision
+  const long double pi = std::acos(-1.L);
+  math::appendToStream(out, pi);
+  EXPECT_EQ(out.str(), "0 456 0 3.14159");
+
+  out << " "
+      << std::setprecision(10);
+
+  math::appendToStream(out, pi);
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654");
+
+  out << " "
+      << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+
+  math::appendToStream(out, pi);
+#ifdef _WIN32
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793");
+#else
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239");
+#endif
+
+  out << " "
+      << std::setprecision(3);
+
+  math::appendToStream(out, pi);
+#ifdef _WIN32
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793 3.14");
+#else
+  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239 3.14");
+#endif
+}


### PR DESCRIPTION
# 🎉 New feature

Part of

* https://github.com/gazebosim/gz-sim/issues/1462

Backports the final `appendToStream` functions after these 2 PRs:

* https://github.com/gazebosim/gz-math/pull/206
* https://github.com/gazebosim/gz-math/pull/376

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

While creating a `Matrix6` class, I thought I'd add it to `ign-math6`, but with the updates that have been made to `Matrix[3|4]` on `main`. One of them requires the use of the `appendToStream` function, which was added to `main` in #206 and improved in #376.

I'm not backporting the uses of that function that were introduced in `main`, because they aren't backwards compatible. I'll use the function in the `Matrix6` PR that is coming up next.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Run the added tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
