### PR TITLE
Remove deprecated appendToStream - they're new on v7

### DIFF
--- a/include/gz/math/Helpers.hh
+++ b/include/gz/math/Helpers.hh
@@ -469,37 +469,6 @@ namespace gz
     /// \brief Append a number to a stream. Makes sure "-0" is returned as "0".
     /// \param[out] _out Output stream.
     /// \param[in] _number Number to append.
-    /// \param[in] _precision Precision for floating point numbers.
-    /// \deprecated Use appendToStream(std::ostream, T) instead.
-    template<typename T>
-    inline void GZ_DEPRECATED(7) appendToStream(
-        std::ostream &_out, T _number, int _precision)
-    {
-      if (std::fpclassify(_number) == FP_ZERO)
-      {
-        _out << 0;
-      }
-      else
-      {
-        _out << precision(_number, _precision);
-      }
-    }
-
-    /// \brief Append a number to a stream, specialized for int.
-    /// \param[out] _out Output stream.
-    /// \param[in] _number Number to append.
-    /// _precision Not used for int.
-    /// \deprecated Use appendToStream(std::ostream, int) instead.
-    template<>
-    inline void GZ_DEPRECATED(7) appendToStream(
-        std::ostream &_out, int _number, int)
-    {
-      _out << _number;
-    }
-
-    /// \brief Append a number to a stream. Makes sure "-0" is returned as "0".
-    /// \param[out] _out Output stream.
-    /// \param[in] _number Number to append.
     template<typename T>
     inline void appendToStream(std::ostream &_out, T _number)
     {

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -985,29 +985,6 @@ TEST(HelpersTest, AppendToStream)
 {
   std::ostringstream out;
 
-  GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
-  // Deprecated in gz-math7
-  math::appendToStream(out, 0.12345678, 3);
-  EXPECT_EQ(out.str(), "0.123");
-
-  out << " ";
-
-  math::appendToStream(out, 0.0f, 5);
-  EXPECT_EQ(out.str(), "0.123 0");
-
-  out << " ";
-
-  math::appendToStream(out, 456, 3);
-  EXPECT_EQ(out.str(), "0.123 0 456");
-
-  out << " ";
-
-  math::appendToStream(out, 0, 3);
-  EXPECT_EQ(out.str(), "0.123 0 456 0");
-
-  out.str("");
-  GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
-
   math::appendToStream(out, 0.0f);
   EXPECT_EQ(out.str(), "0");
 


### PR DESCRIPTION
Follow-up to

* https://github.com/gazebosim/gz-math/pull/206
* https://github.com/gazebosim/gz-math/pull/376

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `appendToStream` functions were added on `main`, so they don't need to be deprecated and can be removed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
