### PR TITLE
ign -> gz Tick-tock Python Libs : gz-math

### DIFF
--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -110,19 +110,20 @@ function(configure_build_install_location _library_name)
   # Install Python library symlinks
   if(${GZ_PYTHON_INSTALL_PATH} MATCHES "gz$")
     cmake_policy(SET CMP0087 NEW)  # Allow evaluation of generator expressions in install(CODE )
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/ignition")
 
     string(REGEX REPLACE "gz$" "ignition" IGN_PYTHON_INSTALL_PATH ${GZ_PYTHON_INSTALL_PATH})
     if (WIN32)  # Windows requires copy instead of symlink
       install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E copy \
-          ${CMAKE_INSTALL_PREFIX}\/${GZ_PYTHON_INSTALL_PATH}\/$<TARGET_FILE_NAME:${_library_name}> \
-          ${PROJECT_BINARY_DIR}\/$<TARGET_FILE_NAME:${_library_name}>)")
+          ../gz/${GZ_PYTHON_INSTALL_PATH}\/$<TARGET_FILE_NAME:${_library_name}> \
+          ${PROJECT_BINARY_DIR}\/ignition/$<TARGET_FILE_NAME:${_library_name}>)")
     else()
       install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \
-          ${CMAKE_INSTALL_PREFIX}\/${GZ_PYTHON_INSTALL_PATH}\/$<TARGET_FILE_NAME:${_library_name}> \
-          ${PROJECT_BINARY_DIR}\/$<TARGET_FILE_NAME:${_library_name}>)")
+          ../gz/$<TARGET_FILE_NAME:${_library_name}> \
+          ${PROJECT_BINARY_DIR}\/ignition/$<TARGET_FILE_NAME:${_library_name}>)")
     endif()
 
-    install(FILES ${PROJECT_BINARY_DIR}\/$<TARGET_FILE_NAME:${_library_name}>
+    install(FILES ${PROJECT_BINARY_DIR}\/ignition/$<TARGET_FILE_NAME:${_library_name}>
       DESTINATION "${IGN_PYTHON_INSTALL_PATH}/"
     )
   endif()


### PR DESCRIPTION
Part of overarching: https://github.com/gazebo-tooling/release-tools/issues/698
Follow-up to: https://github.com/gazebo-tooling/release-tools/issues/765

In https://github.com/gazebo-tooling/release-tools/issues/765, gz-math Python bindings were tick-tocked to allow use of `ignition` and `gz`. But the symlinks that are being created on the debbuilder are malformed, even though local builds work fine...

This PR fixes that by abusing relative links (it breaks on absolute links for some reason.)

Compare the built `.deb` from this
- **broken**: https://build.osrfoundation.org/job/ign-math7-debbuilder/741/
  - (the symlink points to one layer too shallow) (`../../../../usr/lib/XXX`, when it should be `../../../../../usr/lib/XXX`)
- **fixed**: https://build.osrfoundation.org/job/ign-math7-debbuilder/745/
  - (symlink now points to `../gz/XXX`)

Test downstream build using fixed debbuild: [![Build Status](https://build.osrfoundation.org/job/sdformat-ci-pr_any-ubuntu_auto-amd64/3858/badge/icon)](https://build.osrfoundation.org/job/sdformat-ci-pr_any-ubuntu_auto-amd64/3858/)
Build is unstable because of deprecation warnings, not test failures, which this fixes!