### PR TITLE
Fixed quaternion from euler example

### DIFF
--- a/examples/quaternion_from_euler.cc
+++ b/examples/quaternion_from_euler.cc
@@ -53,9 +53,9 @@ int main(int argc, char **argv)
     return -1;
   }
 
-  double roll = GZ_DTOR(strToDouble(argv[1]));
-  double pitch = GZ_DTOR(strToDouble(argv[2]));
-  double yaw = GZ_DTOR(strToDouble(argv[3]));
+  double roll = strToDouble(argv[1]);
+  double pitch = strToDouble(argv[2]);
+  double yaw = strToDouble(argv[3]);
 
   std::cout << "Converting Euler angles:\n";
   printf(" roll  % .6f radians\n"

--- a/examples/quaternion_from_euler.cc
+++ b/examples/quaternion_from_euler.cc
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
   if (argc != 4)
   {
     std::cerr << "Invalid usage\n\n"
-              << "Usage (angles specified in degrees):\n"
+              << "Usage (angles specified in radians):\n"
               << "  quaternion_from_euler "
               << "<float_roll> <float_pitch> <float_yaw>\n\n"
               << "Example\n"


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary
Fixed quaternion from euler example. Values are already in radians.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
