### PR TITLE
Add pybind11 module as MODULE

### DIFF
--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 message(STATUS "Building pybind11 interfaces")
 # Split from main extension and converted to pybind11
-pybind11_add_module(math SHARED
+pybind11_add_module(math MODULE
   src/_gz_math_pybind11.cc
   src/Angle.cc
   src/AxisAlignedBox.cc


### PR DESCRIPTION
# 🦟 Bug fix

This fixes an issue with linking to python libraries on macOS.

## Summary

When trying to update the homebrew bottles in https://github.com/osrf/homebrew-simulation/pull/2036 so that python bindings can be used without setting the `PYTHONPATH`, I ran into the following error:

~~~
osrf/simulation/gz-math7:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/opt/gz-math7/lib/python3.10/site-packages/gz/math.cpython-310-darwin.so
      /usr/local/opt/gz-math7/lib/python3.10/site-packages/ignition/math.cpython-310-darwin.so
~~~

I found that using `MODULE` instead of `SHARED` in our `pybind11_add_module` call fixes this issue.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
