### PR TITLE
Bugfix/matrix buffer protocol

### DIFF
--- a/include/gz/math/Matrix3.hh
+++ b/include/gz/math/Matrix3.hh
@@ -636,7 +636,7 @@ namespace gz
       }
 
       /// \brief the 3x3 matrix
-      private: T data[3][3];
+      T data[3][3];
     };
 
     namespace detail {

--- a/include/gz/math/Matrix4.hh
+++ b/include/gz/math/Matrix4.hh
@@ -844,7 +844,7 @@ namespace gz
       }
 
       /// \brief The 4x4 matrix
-      private: T data[4][4];
+      T data[4][4];
     };
 
     namespace detail {

--- a/include/gz/math/Matrix6.hh
+++ b/include/gz/math/Matrix6.hh
@@ -553,7 +553,7 @@ namespace gz
       }
 
       /// \brief The 6x6 matrix
-      private: T data[MatrixSize][MatrixSize];
+      T data[MatrixSize][MatrixSize];
     };
 
     namespace detail {

--- a/src/python_pybind11/src/Matrix3.hh
+++ b/src/python_pybind11/src/Matrix3.hh
@@ -123,7 +123,18 @@ void helpDefineMathMatrix3(py::module &m, const std::string &typestr)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
     .def("__str__", toString)
-    .def("__repr__", toString);
+    .def("__repr__", toString)
+    .def_buffer([](Class &self) -> py::buffer_info {
+      return py::buffer_info(
+          self.data,  // Pointer to buffer
+          sizeof(T),  // Size of one scalar
+          py::format_descriptor<T>::format(),
+          2,  // Number of dimensions
+          { 3, 3 },  // Buffer dimensions
+          // Strides (in bytes) for each dimension
+          { sizeof(T) * 3, sizeof(T) }
+      );
+    });
 }
 }  // namespace python
 }  // namespace math

--- a/src/python_pybind11/src/Matrix4.hh
+++ b/src/python_pybind11/src/Matrix4.hh
@@ -145,7 +145,18 @@ void helpDefineMathMatrix4(py::module &m, const std::string &typestr)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
     .def("__str__", toString)
-    .def("__repr__", toString);
+    .def("__repr__", toString)
+    .def_buffer([](Class &self) -> py::buffer_info {
+      return py::buffer_info(
+          self.data,  // Pointer to buffer
+          sizeof(T),  // Size of one scalar
+          py::format_descriptor<T>::format(),
+          2,  // Number of dimensions
+          { 4, 4 },  // Buffer dimensions
+          // Strides (in bytes) for each dimension
+          { sizeof(T) * 4, sizeof(T) }
+      );
+    });
 }
 }  // namespace python
 }  // namespace math

--- a/src/python_pybind11/src/Matrix6.hh
+++ b/src/python_pybind11/src/Matrix6.hh
@@ -99,7 +99,18 @@ void helpDefineMathMatrix6(py::module &_m, const std::string &_typestr)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
     .def("__str__", toString)
-    .def("__repr__", toString);
+    .def("__repr__", toString)
+    .def_buffer([](Class &self) -> py::buffer_info {
+      return py::buffer_info(
+          self.data,  // Pointer to buffer
+          sizeof(T),  // Size of one scalar
+          py::format_descriptor<T>::format(),
+          2,  // Number of dimensions
+          { 6, 6 },  // Buffer dimensions
+          // Strides (in bytes) for each dimension
+          { sizeof(T) * 6, sizeof(T) }
+      );
+    });
 }
 }  // namespace python
 }  // namespace math

--- a/src/python_pybind11/test/Matrix3_TEST.py
+++ b/src/python_pybind11/test/Matrix3_TEST.py
@@ -118,6 +118,16 @@ class TestMatrix3(unittest.TestCase):
 
         self.assertEqual(str(matrix), "1 2 3 4 5 6 7 8 9")
 
+    def test_buffer(self):
+        elements = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        matrix = Matrix3d(*elements)
+
+        self.assertEqual(matrix(1,2), memoryview(matrix)[1,2])
+        self.assertTrue(memoryview(matrix).c_contiguous)
+        # Have to cast through bytes for some reason...
+        aslist = memoryview(matrix).cast('b', (3 * 3 * 8,)).cast('d', (3 * 3,)).tolist()
+        self.assertEqual(elements, aslist)
+
     def test_vector3_mul(self):
         matrix = Matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9)
 

--- a/src/python_pybind11/test/Matrix4_TEST.py
+++ b/src/python_pybind11/test/Matrix4_TEST.py
@@ -375,6 +375,27 @@ class TestMatrix4(unittest.TestCase):
 
         self.assertEqual(str(matA), "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16")
 
+    def test_buffer(self):
+        matrix = Matrix4d(1, 2, 3, 4,
+                          5, 6, 7, 8,
+                          9, 10, 11, 12,
+                          13, 14, 15, 16)
+
+        self.assertEqual(matrix(2,3), memoryview(matrix)[2,3])
+
+    def test_buffer(self):
+        elements = [1.0, 2.0, 3.0, 4.0,
+                    5.0, 6.0, 7.0, 8.0,
+                    9.0, 10.0, 11.0, 12.0,
+                    13.0, 14.0, 15.0, 16.0]
+        matrix = Matrix4d(*elements)
+
+        self.assertEqual(matrix(2,3), memoryview(matrix)[2,3])
+        self.assertTrue(memoryview(matrix).c_contiguous)
+        # Have to cast through bytes for some reason...
+        aslist = memoryview(matrix).cast('b', (4 * 4 * 8,)).cast('d', (4 * 4,)).tolist()
+        self.assertEqual(elements, aslist)
+
     def test_not_equal(self):
         matrix1 = Matrix4d()
         matrix2 = Matrix4d()

--- a/src/python_pybind11/test/Matrix6_TEST.py
+++ b/src/python_pybind11/test/Matrix6_TEST.py
@@ -152,6 +152,36 @@ class TestMatrix6(unittest.TestCase):
             "24 25 26 27 28 29 "
             "30 31 32 33 34 35")
 
+
+    def test_buffer(self):
+        matA = Matrix6d(
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
+            6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+            12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
+            18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
+            24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
+            30.0, 31.0, 32.0, 33.0, 34.0, 35.0)
+
+        self.assertEqual(matA(2,3), memoryview(matA)[2,3])
+
+
+    def test_buffer(self):
+        elements = [
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
+            6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
+            12.0, 13.0, 14.0, 15.0, 16.0, 17.0,
+            18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
+            24.0, 25.0, 26.0, 27.0, 28.0, 29.0,
+            30.0, 31.0, 32.0, 33.0, 34.0, 35.0,
+        ]
+        matrix = Matrix6d(*elements)
+
+        self.assertEqual(matrix(2,3), memoryview(matrix)[2,3])
+        self.assertTrue(memoryview(matrix).c_contiguous)
+        # Have to cast through bytes for some reason...
+        aslist = memoryview(matrix).cast('b', (6 * 6 * 8,)).cast('d', (6 * 6,)).tolist()
+        self.assertEqual(elements, aslist)
+
     def test_not_equal(self):
         matrix1 = Matrix6d()
         matrix2 = Matrix6d()


### PR DESCRIPTION
## Summary
```
>>> list(np.array(Matrix4d()))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: iteration over a 0-d array
```

Now:
```
>>> m = Matrix4d(0.0, 0.1, 0.2, 0.3, 10,11,12,13,20,21,22,23,30,31,32,33)
0 0.1 0.2 0.3 10 11 12 13 20 21 22 23 30 31 32 33
>>> memoryview(m)[0,0]
0.0
>>> memoryview(m)[2,1]
21.0
>>> m(2,1)
21.0
>>> np.array(m)[2,1]
21.0
>>> np.array(m).tolist()
[[0.0, 0.1, 0.2, 0.3], [10.0, 11.0, 12.0, 13.0], [20.0, 21.0, 22.0, 23.0], [30.0, 31.0, 32.0, 33.0]]
```
## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


I haven't signed off yet cause I want feedback on making `data` non-private - is there another way to access that data from the python header - some sort of `friend` thing?