### PR TITLE
Migration guide: remove outdated entry

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -74,9 +74,6 @@ release will remove the deprecated code.
     + ***Deprecation:*** public: void W(T)
     + ***Replacement:*** public: void SetW(T)
 
-1. **Helpers.hh**
-    + **Deprecation:** template<typename T> inline void appendToStream(std::ostream, T, int)
-    + **Replacement:** template<typename T> inline void appendToStream(std::ostream, T)
 1. The `ignition` namespace is deprecated and will be removed in future versions.  Use `gz` instead.
 1. Header files under `ignition/...` are deprecated and will be removed in future versions.
    Use `gz/...` instead.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes migration guide as follow up to #454

## Summary

A variant of `appendToStream` was deprecated in #376, but then it was removed in https://github.com/gazebosim/gz-math/pull/454 after recalling that it hadn't yet been released. This updates the Migration guide to remove the deprecation entry for the removed method.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
