### PR TITLE
tutorial update: macOS binary install

### DIFF
--- a/tutorials/installation.md
+++ b/tutorials/installation.md
@@ -37,7 +37,7 @@ you should use `ign-math<#>`.
 
 On macOS, add OSRF packages:
   ```
-  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   brew tap osrf/simulation
   ```
 
@@ -46,9 +46,8 @@ Install Gazebo Math:
   brew install gz-math<#>
   ```
 
-Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
-which version you need. From version 7 you should use `gz-math<#>` but for lower versions
-you should use `ign-math<#>`.
+Be sure to replace `<#>` with a number value, such as 6 or 7, depending on
+which version you need.
 
 ## Windows
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes macOS binary install tutorial. Part of https://github.com/gazebosim/garden-tutorial-party/issues/210

## Summary

* Update brew install command (see https://brew.sh )
* Remove instructions about using ign-* for old formulae, since all current formulae have gz-* aliases.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
