### PR TITLE
Fixed cppgetstarted visualization

### DIFF
--- a/tutorials/cppgetstarted.md
+++ b/tutorials/cppgetstarted.md
@@ -71,14 +71,14 @@ To compile this code on UNIX with pkg-config, use the following command:
 
 ```{.bash}
 c++ $(pkg-config --cflags gz-math7) main.cpp -o main
-~~~
+```
 
 The program can then be run as:
 
 ```{.bash}
 $ ./main
 Distance from 1 3 5 to 2 4 6 is 1.73205
-~~~
+```
 
 ## Bonus: Vector2 Example
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The tutorial is not properly render https://gazebosim.org/api/math/7/cppgetstarted.html This should fix the issue.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
