### PR TITLE
Fix link of installation tutorial to point to 7 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Math types.
 
 # Install
 
-See the [installation tutorial](https://gazebosim.org/api/math/6.8/install.html).
+See the [installation tutorial](https://gazebosim.org/api/math/7/install.html).
 
 # Usage
 


### PR DESCRIPTION
# 🦟 Bug fix

While navigating with @giotherobot we noticed that the link was pointing to the 6.8 version. Not sure if there is a smarted fix, link linking to latest or similar.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
