### PR TITLE
buffer_protocol for vectors and matrices in python bindings

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -2,6 +2,8 @@ libeigen3-dev
 libgz-cmake4-dev
 libgz-utils3-dev
 libpython3-dev
+python3-distutils
+python3-numpy
 python3-pybind11
 python3-pytest
 ruby-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -2,7 +2,6 @@ libeigen3-dev
 libgz-cmake4-dev
 libgz-utils3-dev
 libpython3-dev
-python3-distutils
 python3-numpy
 python3-pybind11
 python3-pytest

--- a/include/gz/math/Matrix3.hh
+++ b/include/gz/math/Matrix3.hh
@@ -576,6 +576,15 @@ namespace gz::math
       return _in;
     }
 
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks It's preferable not to rely on it.
+    /// \return The pointer to the underlying data.
+    public: T* Data()
+    {
+      return this->data[0];
+    }
+
     /// \brief the 3x3 matrix
     private: T data[3][3];
   };

--- a/include/gz/math/Matrix3.hh
+++ b/include/gz/math/Matrix3.hh
@@ -576,10 +576,11 @@ namespace gz::math
       return _in;
     }
 
-    /// \brief Underlying data pointer
-    /// \remarks This method is intended for python bindings (numpy).
-    /// \remarks It's preferable not to rely on it.
-    /// \return The pointer to the underlying data.
+  /// \brief Underlying data pointer
+  /// \remarks This method is intended for python bindings (numpy).
+  /// \remarks The bounds-checking array subscript operator is much preferred
+  /// for element access from C++. \return A pointer to the underlying data
+  /// array.
     public: T* Data()
     {
       return this->data[0];

--- a/include/gz/math/Matrix3.hh
+++ b/include/gz/math/Matrix3.hh
@@ -576,11 +576,11 @@ namespace gz::math
       return _in;
     }
 
-  /// \brief Underlying data pointer
-  /// \remarks This method is intended for python bindings (numpy).
-  /// \remarks The bounds-checking array subscript operator is much preferred
-  /// for element access from C++. \return A pointer to the underlying data
-  /// array.
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks The bounds-checking array subscript operator is much preferred
+    /// for element access from C++.
+    /// \return A pointer to the underlying data array.
     public: T* Data()
     {
       return this->data[0];

--- a/include/gz/math/Matrix4.hh
+++ b/include/gz/math/Matrix4.hh
@@ -829,10 +829,11 @@ namespace gz::math
                 0,      0,         0,        1);
     }
 
-    /// \brief Underlying data pointer
-    /// \remarks This method is intended for python bindings (numpy).
-    /// \remarks It's preferable not to rely on it.
-    /// \return The pointer to the underlying data.
+  /// \brief Underlying data pointer
+  /// \remarks This method is intended for python bindings (numpy).
+  /// \remarks The bounds-checking array subscript operator is much preferred
+  /// for element access from C++. \return A pointer to the underlying data
+  /// array.
     public: T* Data()
     {
       return this->data[0];

--- a/include/gz/math/Matrix4.hh
+++ b/include/gz/math/Matrix4.hh
@@ -829,6 +829,15 @@ namespace gz::math
                 0,      0,         0,        1);
     }
 
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks It's preferable not to rely on it.
+    /// \return The pointer to the underlying data.
+    public: T* Data()
+    {
+      return this->data[0];
+    }
+
     /// \brief The 4x4 matrix
     private: T data[4][4];
   };

--- a/include/gz/math/Matrix4.hh
+++ b/include/gz/math/Matrix4.hh
@@ -829,11 +829,11 @@ namespace gz::math
                 0,      0,         0,        1);
     }
 
-  /// \brief Underlying data pointer
-  /// \remarks This method is intended for python bindings (numpy).
-  /// \remarks The bounds-checking array subscript operator is much preferred
-  /// for element access from C++. \return A pointer to the underlying data
-  /// array.
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks The bounds-checking array subscript operator is much preferred
+    /// for element access from C++.
+    /// \return A pointer to the underlying data array.
     public: T* Data()
     {
       return this->data[0];

--- a/include/gz/math/Matrix6.hh
+++ b/include/gz/math/Matrix6.hh
@@ -541,10 +541,11 @@ namespace gz::math
       return _in;
     }
 
-    /// \brief Underlying data pointer
-    /// \remarks This method is intended for python bindings (numpy).
-    /// \remarks It's preferable not to rely on it.
-    /// \return The pointer to the underlying data.
+  /// \brief Underlying data pointer
+  /// \remarks This method is intended for python bindings (numpy).
+  /// \remarks The bounds-checking array subscript operator is much preferred
+  /// for element access from C++. \return A pointer to the underlying data
+  /// array.
     public: T* Data()
     {
       return this->data[0];

--- a/include/gz/math/Matrix6.hh
+++ b/include/gz/math/Matrix6.hh
@@ -541,6 +541,15 @@ namespace gz::math
       return _in;
     }
 
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks It's preferable not to rely on it.
+    /// \return The pointer to the underlying data.
+    public: T* Data()
+    {
+      return this->data[0];
+    }
+
     /// \brief The 6x6 matrix
     private: T data[MatrixSize][MatrixSize];
   };

--- a/include/gz/math/Matrix6.hh
+++ b/include/gz/math/Matrix6.hh
@@ -541,11 +541,11 @@ namespace gz::math
       return _in;
     }
 
-  /// \brief Underlying data pointer
-  /// \remarks This method is intended for python bindings (numpy).
-  /// \remarks The bounds-checking array subscript operator is much preferred
-  /// for element access from C++. \return A pointer to the underlying data
-  /// array.
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks The bounds-checking array subscript operator is much preferred
+    /// for element access from C++.
+    /// \return A pointer to the underlying data array.
     public: T* Data()
     {
       return this->data[0];

--- a/include/gz/math/Vector2.hh
+++ b/include/gz/math/Vector2.hh
@@ -556,6 +556,15 @@ namespace gz::math
       return _in;
     }
 
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks It's preferable not to rely on it.
+    /// \return The pointer to the underlying data.
+    public: T* Data()
+    {
+      return this->data;
+    }
+
     /// \brief The x and y values.
     private: T data[2];
   };

--- a/include/gz/math/Vector2.hh
+++ b/include/gz/math/Vector2.hh
@@ -556,10 +556,11 @@ namespace gz::math
       return _in;
     }
 
-    /// \brief Underlying data pointer
-    /// \remarks This method is intended for python bindings (numpy).
-    /// \remarks It's preferable not to rely on it.
-    /// \return The pointer to the underlying data.
+  /// \brief Underlying data pointer
+  /// \remarks This method is intended for python bindings (numpy).
+  /// \remarks The bounds-checking array subscript operator is much preferred
+  /// for element access from C++. \return A pointer to the underlying data
+  /// array.
     public: T* Data()
     {
       return this->data;

--- a/include/gz/math/Vector2.hh
+++ b/include/gz/math/Vector2.hh
@@ -556,11 +556,11 @@ namespace gz::math
       return _in;
     }
 
-  /// \brief Underlying data pointer
-  /// \remarks This method is intended for python bindings (numpy).
-  /// \remarks The bounds-checking array subscript operator is much preferred
-  /// for element access from C++. \return A pointer to the underlying data
-  /// array.
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks The bounds-checking array subscript operator is much preferred
+    /// for element access from C++.
+    /// \return A pointer to the underlying data array.
     public: T* Data()
     {
       return this->data;

--- a/include/gz/math/Vector3.hh
+++ b/include/gz/math/Vector3.hh
@@ -746,6 +746,15 @@ namespace gz::math
       return _in;
     }
 
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks It's preferable not to rely on it.
+    /// \return The pointer to the underlying data.
+    public: T* Data()
+    {
+      return this->data;
+    }
+
     /// \brief The x, y, and z values
     private: T data[3];
   };

--- a/include/gz/math/Vector3.hh
+++ b/include/gz/math/Vector3.hh
@@ -746,10 +746,11 @@ namespace gz::math
       return _in;
     }
 
-    /// \brief Underlying data pointer
-    /// \remarks This method is intended for python bindings (numpy).
-    /// \remarks It's preferable not to rely on it.
-    /// \return The pointer to the underlying data.
+  /// \brief Underlying data pointer
+  /// \remarks This method is intended for python bindings (numpy).
+  /// \remarks The bounds-checking array subscript operator is much preferred
+  /// for element access from C++. \return A pointer to the underlying data
+  /// array.
     public: T* Data()
     {
       return this->data;

--- a/include/gz/math/Vector3.hh
+++ b/include/gz/math/Vector3.hh
@@ -746,11 +746,11 @@ namespace gz::math
       return _in;
     }
 
-  /// \brief Underlying data pointer
-  /// \remarks This method is intended for python bindings (numpy).
-  /// \remarks The bounds-checking array subscript operator is much preferred
-  /// for element access from C++. \return A pointer to the underlying data
-  /// array.
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks The bounds-checking array subscript operator is much preferred
+    /// for element access from C++.
+    /// \return A pointer to the underlying data array.
     public: T* Data()
     {
       return this->data;

--- a/include/gz/math/Vector4.hh
+++ b/include/gz/math/Vector4.hh
@@ -706,6 +706,15 @@ namespace gz::math
       return _in;
     }
 
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks It's preferable not to rely on it.
+    /// \return The pointer to the underlying data.
+    public: T* Data()
+    {
+      return this->data;
+    }
+
     /// \brief Data values, 0==x, 1==y, 2==z, 3==w
     private: T data[4];
   };

--- a/include/gz/math/Vector4.hh
+++ b/include/gz/math/Vector4.hh
@@ -706,10 +706,11 @@ namespace gz::math
       return _in;
     }
 
-    /// \brief Underlying data pointer
-    /// \remarks This method is intended for python bindings (numpy).
-    /// \remarks It's preferable not to rely on it.
-    /// \return The pointer to the underlying data.
+  /// \brief Underlying data pointer
+  /// \remarks This method is intended for python bindings (numpy).
+  /// \remarks The bounds-checking array subscript operator is much preferred
+  /// for element access from C++. \return A pointer to the underlying data
+  /// array.
     public: T* Data()
     {
       return this->data;

--- a/include/gz/math/Vector4.hh
+++ b/include/gz/math/Vector4.hh
@@ -706,11 +706,11 @@ namespace gz::math
       return _in;
     }
 
-  /// \brief Underlying data pointer
-  /// \remarks This method is intended for python bindings (numpy).
-  /// \remarks The bounds-checking array subscript operator is much preferred
-  /// for element access from C++. \return A pointer to the underlying data
-  /// array.
+    /// \brief Underlying data pointer
+    /// \remarks This method is intended for python bindings (numpy).
+    /// \remarks The bounds-checking array subscript operator is much preferred
+    /// for element access from C++.
+    /// \return A pointer to the underlying data array.
     public: T* Data()
     {
       return this->data;

--- a/src/Matrix3_TEST.cc
+++ b/src/Matrix3_TEST.cc
@@ -417,3 +417,16 @@ TEST(Matrix3dTest, From2Axes)
   m1.SetFrom2Axes(v1, v2);
   EXPECT_EQ(math::Matrix3d::Zero - math::Matrix3d::Identity, m1);
 }
+
+/////////////////////////////////////////////////
+TEST(Matrix3dTest, Data)
+{
+  math::Matrix3d m1(0, 1, 2,
+                    3, 4, 5,
+                    6, 7, 8);
+
+  for (int i = 0; i < 9; ++i) EXPECT_EQ(m1.Data()[i], i);
+  math::Matrix3d m2 = math::Matrix3d::Zero;
+  for (int i = 0; i < 9; ++i) m2.Data()[i] = i;
+  EXPECT_EQ(m1, m2);
+}

--- a/src/Matrix4_TEST.cc
+++ b/src/Matrix4_TEST.cc
@@ -741,3 +741,17 @@ TEST(Matrix4dTest, LookAt)
                 .Pose(),
             math::Pose3d(1, 1, 1, GZ_PI_4, 0, GZ_PI));
 }
+
+/////////////////////////////////////////////////
+TEST(Matrix4dTest, Data)
+{
+  math::Matrix4d m1(0, 1, 2, 3,
+                    4, 5, 6, 7,
+                    8, 9, 10, 11,
+                    12, 13, 14, 15);
+
+  for (int i = 0; i < 16; ++i) EXPECT_EQ(m1.Data()[i], i);
+  math::Matrix4d m2 = math::Matrix4d::Zero;
+  for (int i = 0; i < 16; ++i) m2.Data()[i] = i;
+  EXPECT_EQ(m1, m2);
+}

--- a/src/Matrix6_TEST.cc
+++ b/src/Matrix6_TEST.cc
@@ -393,3 +393,19 @@ TEST(Matrix6dTest, SetValue)
       4, 3, 2, 1, 0, -1,
       5, 4, 3, 2, 1, 0));
 }
+
+/////////////////////////////////////////////////
+TEST(Matrix6dTest, Data)
+{
+  math::Matrix6d m1(0, 1, 2, 3, 4, 5,
+                    6, 7, 8, 9, 10, 11,
+                    12, 13, 14, 15, 16, 17,
+                    18, 19, 20, 21, 22, 23,
+                    24, 25, 26, 27, 28, 29,
+                    30, 31, 32, 33, 34, 35);
+
+  for (int i = 0; i < 36; ++i) EXPECT_EQ(m1.Data()[i], i);
+  math::Matrix6d m2 = math::Matrix6d::Zero;
+  for (int i = 0; i < 36; ++i) m2.Data()[i] = i;
+  EXPECT_EQ(m1, m2);
+}

--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -476,3 +476,15 @@ TEST(Vector2Test, NaN)
   EXPECT_EQ(math::Vector2f::Zero, nanVecF);
   EXPECT_TRUE(nanVecF.IsFinite());
 }
+
+/////////////////////////////////////////////////
+TEST(Vector2Test, Data)
+{
+  math::Vector2d v(0, 1);
+  for (int i = 0; i < 2; ++i) EXPECT_EQ(v.Data()[i], v[i]);
+
+  auto v2 = math::Vector2d::Zero;
+  for (int i = 0; i < 2; ++i) v2.Data()[i] = i;
+
+  EXPECT_EQ(v, v2);
+}

--- a/src/Vector3_TEST.cc
+++ b/src/Vector3_TEST.cc
@@ -576,3 +576,15 @@ TEST(Vector3dTest, OperatorStreamOut)
   stream << std::setprecision(1) << std::fixed << v;
   EXPECT_EQ(stream.str(), "0.1 1.2 2.3");
 }
+
+/////////////////////////////////////////////////
+TEST(Vector3Test, Data)
+{
+  math::Vector3d v(0, 1, 2);
+  for (int i = 0; i < 3; ++i) EXPECT_EQ(v.Data()[i], v[i]);
+
+  auto v2 = math::Vector3d::Zero;
+  for (int i = 0; i < 3; ++i) v2.Data()[i] = i;
+
+  EXPECT_EQ(v, v2);
+}

--- a/src/Vector4_TEST.cc
+++ b/src/Vector4_TEST.cc
@@ -480,3 +480,15 @@ TEST(Vector4Test, NaN)
   EXPECT_EQ(math::Vector4f::Zero, nanVecF);
   EXPECT_TRUE(nanVecF.IsFinite());
 }
+
+/////////////////////////////////////////////////
+TEST(Vector4Test, Data)
+{
+  math::Vector4d v(0, 1, 2, 3);
+  for (int i = 0; i < 4; ++i) EXPECT_EQ(v.Data()[i], v[i]);
+
+  auto v2 = math::Vector4d::Zero;
+  for (int i = 0; i < 4; ++i) v2.Data()[i] = i;
+
+  EXPECT_EQ(v, v2);
+}

--- a/src/python_pybind11/src/Matrix3.hh
+++ b/src/python_pybind11/src/Matrix3.hh
@@ -51,7 +51,7 @@ template<typename T>
 void helpDefineMathMatrix3(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Matrix3<T>;
-  const int mat_size = 3;
+  static constexpr int mat_size = 3;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;

--- a/src/python_pybind11/src/Matrix3.hh
+++ b/src/python_pybind11/src/Matrix3.hh
@@ -51,6 +51,7 @@ template<typename T>
 void helpDefineMathMatrix3(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Matrix3<T>;
+  const int mat_size = 3;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;
@@ -122,6 +123,16 @@ void helpDefineMathMatrix3(py::module &m, const std::string &typestr)
     }, "memo"_a)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
+    .def_buffer([](Class &self) -> py::buffer_info {
+        return py::buffer_info(
+            self.Data(),
+            sizeof(T),
+            py::format_descriptor<T>::format(),
+            2,
+            { mat_size, mat_size },
+            { mat_size * sizeof(T), sizeof(T) }
+        );
+    })
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/src/Matrix4.hh
+++ b/src/python_pybind11/src/Matrix4.hh
@@ -51,7 +51,7 @@ template<typename T>
 void helpDefineMathMatrix4(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Matrix4<T>;
-  const int mat_size = 4;
+  static constexpr int mat_size = 4;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;

--- a/src/python_pybind11/src/Matrix4.hh
+++ b/src/python_pybind11/src/Matrix4.hh
@@ -51,6 +51,7 @@ template<typename T>
 void helpDefineMathMatrix4(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Matrix4<T>;
+  const int mat_size = 4;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;
@@ -144,6 +145,16 @@ void helpDefineMathMatrix4(py::module &m, const std::string &typestr)
     }, "memo"_a)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
+    .def_buffer([](Class &self) -> py::buffer_info {
+        return py::buffer_info(
+            self.Data(),
+            sizeof(T),
+            py::format_descriptor<T>::format(),
+            2,
+            { mat_size, mat_size },
+            { mat_size * sizeof(T), sizeof(T) }
+        );
+    })
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/src/Matrix6.hh
+++ b/src/python_pybind11/src/Matrix6.hh
@@ -51,7 +51,7 @@ template<typename T>
 void helpDefineMathMatrix6(py::module &_m, const std::string &_typestr)
 {
   using Class = Matrix6<T>;
-  const int mat_size = 6;
+  static const int mat_size = 6;
   auto toString = [](const Class &_si) {
     std::stringstream stream;
     stream << _si;

--- a/src/python_pybind11/src/Matrix6.hh
+++ b/src/python_pybind11/src/Matrix6.hh
@@ -51,6 +51,7 @@ template<typename T>
 void helpDefineMathMatrix6(py::module &_m, const std::string &_typestr)
 {
   using Class = Matrix6<T>;
+  const int mat_size = 6;
   auto toString = [](const Class &_si) {
     std::stringstream stream;
     stream << _si;
@@ -98,6 +99,16 @@ void helpDefineMathMatrix6(py::module &_m, const std::string &_typestr)
     }, "memo"_a)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
+    .def_buffer([](Class &self) -> py::buffer_info {
+        return py::buffer_info(
+            self.Data(),
+            sizeof(T),
+            py::format_descriptor<T>::format(),
+            2,
+            { mat_size, mat_size },
+            { mat_size * sizeof(T), sizeof(T) }
+        );
+    })
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/src/Quaternion.hh
+++ b/src/python_pybind11/src/Quaternion.hh
@@ -20,6 +20,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
@@ -62,7 +63,6 @@ void helpDefineMathQuaternion(py::module &m, const std::string &typestr)
   std::string pyclass_name = typestr;
   py::class_<Class>(m,
                     pyclass_name.c_str(),
-                    py::buffer_protocol(),
                     py::dynamic_attr())
     .def(py::init<>())
     .def(py::init<T, T, T, T>())
@@ -210,6 +210,9 @@ void helpDefineMathQuaternion(py::module &m, const std::string &typestr)
     }, "memo"_a)
     .def_readonly_static("IDENTITY", &Class::Identity, "Identity matrix")
     .def_readonly_static("ZERO", &Class::Zero, "Zero matrix")
+    .def("xyzw", [](const Class &self){
+        return std::vector<T> { self.X(), self.Y(), self.Z(), self.W() };
+      }, "Number of elements in the vector")
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/src/Vector2.hh
+++ b/src/python_pybind11/src/Vector2.hh
@@ -43,6 +43,7 @@ template<typename T>
 void helpDefineMathVector2(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Vector2<T>;
+  const int vec_size = 2;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;
@@ -132,10 +133,24 @@ void helpDefineMathVector2(py::module &m, const std::string &typestr)
     .def("__deepcopy__", [](const Class &self, py::dict) {
       return Class(self);
     }, "memo"_a)
-    .def("__getitem__",
-         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
-    .def("__setitem__",
-         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
+    .def("__getitem__", [](const Class &self, unsigned index) {
+        if (index >= vec_size) throw py::index_error("Invalid index");
+        return self[index];
+      })
+    .def("__setitem__", [](Class* vec, unsigned index, T val) {
+        if (index >= vec_size) throw py::index_error("Invalid index");
+        (*vec)[index] = val;
+      })
+    .def_buffer([](Class &self) -> py::buffer_info {
+        return py::buffer_info(
+            self.Data(),
+            sizeof(T),
+            py::format_descriptor<T>::format(),
+            1,
+            { vec_size },
+            { sizeof(T) }
+        );
+    })
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/src/Vector2.hh
+++ b/src/python_pybind11/src/Vector2.hh
@@ -43,7 +43,7 @@ template<typename T>
 void helpDefineMathVector2(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Vector2<T>;
-  const int vec_size = 2;
+  static constexpr int vec_size = 2;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;

--- a/src/python_pybind11/src/Vector3.hh
+++ b/src/python_pybind11/src/Vector3.hh
@@ -43,7 +43,7 @@ template<typename T>
 void helpDefineMathVector3(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Vector3<T>;
-  const int vec_size = 3;
+  static constexpr int vec_size = 3;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;

--- a/src/python_pybind11/src/Vector3.hh
+++ b/src/python_pybind11/src/Vector3.hh
@@ -43,6 +43,7 @@ template<typename T>
 void helpDefineMathVector3(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Vector3<T>;
+  const int vec_size = 3;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;
@@ -159,10 +160,24 @@ void helpDefineMathVector3(py::module &m, const std::string &typestr)
     .def("__deepcopy__", [](const Class &self, py::dict) {
       return Class(self);
     }, "memo"_a)
-    .def("__getitem__",
-         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
-    .def("__setitem__",
-         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
+    .def("__getitem__", [](const Class &self, unsigned index) {
+        if (index >= vec_size) throw py::index_error("Invalid index");
+        return self[index];
+      })
+    .def("__setitem__", [](Class* vec, unsigned index, T val) {
+        if (index >= vec_size) throw py::index_error("Invalid index");
+        (*vec)[index] = val;
+      })
+    .def_buffer([](Class &self) -> py::buffer_info {
+        return py::buffer_info(
+            self.Data(),
+            sizeof(T),
+            py::format_descriptor<T>::format(),
+            1,
+            { vec_size },
+            { sizeof(T) }
+        );
+    })
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/src/Vector4.hh
+++ b/src/python_pybind11/src/Vector4.hh
@@ -43,7 +43,7 @@ template<typename T>
 void helpDefineMathVector4(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Vector4<T>;
-  const int vec_size = 4;
+  static const int vec_size = 4;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;

--- a/src/python_pybind11/src/Vector4.hh
+++ b/src/python_pybind11/src/Vector4.hh
@@ -43,6 +43,7 @@ template<typename T>
 void helpDefineMathVector4(py::module &m, const std::string &typestr)
 {
   using Class = gz::math::Vector4<T>;
+  const int vec_size = 4;
   auto toString = [](const Class &si) {
     std::stringstream stream;
     stream << si;
@@ -139,10 +140,24 @@ void helpDefineMathVector4(py::module &m, const std::string &typestr)
     .def("__deepcopy__", [](const Class &self, py::dict) {
       return Class(self);
     }, "memo"_a)
-    .def("__getitem__",
-         py::overload_cast<const std::size_t>(&Class::operator[], py::const_))
-    .def("__setitem__",
-         [](Class* vec, unsigned index, T val) { (*vec)[index] = val; })
+    .def("__getitem__", [](const Class &self, unsigned index) {
+        if (index >= vec_size) throw py::index_error("Invalid index");
+        return self[index];
+      })
+    .def("__setitem__", [](Class* vec, unsigned index, T val) {
+        if (index >= vec_size) throw py::index_error("Invalid index");
+        (*vec)[index] = val;
+      })
+    .def_buffer([](Class &self) -> py::buffer_info {
+        return py::buffer_info(
+            self.Data(),
+            sizeof(T),
+            py::format_descriptor<T>::format(),
+            1,
+            { vec_size },
+            { sizeof(T) }
+        );
+    })
     .def("__str__", toString)
     .def("__repr__", toString);
 }

--- a/src/python_pybind11/test/Matrix3_TEST.py
+++ b/src/python_pybind11/test/Matrix3_TEST.py
@@ -14,9 +14,10 @@
 
 import math
 import unittest
-from gz.math8 import Matrix3d
+from gz.math8 import Matrix3d, Matrix3f
 from gz.math8 import Quaterniond
 from gz.math8 import Vector3d
+import test_common
 
 
 class TestMatrix3(unittest.TestCase):
@@ -333,6 +334,10 @@ class TestMatrix3(unittest.TestCase):
                        0,  0, -1)
         q2 = Quaterniond(mat)
         self.assertTrue(q == q2)
+
+    def test_buffer(self):
+        test_common.test_matrix(self, 3, Matrix3d)
+        test_common.test_matrix(self, 3, Matrix3f)
 
 
 if __name__ == '__main__':

--- a/src/python_pybind11/test/Matrix3_TEST.py
+++ b/src/python_pybind11/test/Matrix3_TEST.py
@@ -17,7 +17,7 @@ import unittest
 from gz.math8 import Matrix3d, Matrix3f
 from gz.math8 import Quaterniond
 from gz.math8 import Vector3d
-import test_common
+import numpy_helpers
 
 
 class TestMatrix3(unittest.TestCase):
@@ -336,8 +336,8 @@ class TestMatrix3(unittest.TestCase):
         self.assertTrue(q == q2)
 
     def test_buffer(self):
-        test_common.test_matrix(self, 3, Matrix3d)
-        test_common.test_matrix(self, 3, Matrix3f)
+        numpy_helpers.test_matrix(self, 3, Matrix3d)
+        numpy_helpers.test_matrix(self, 3, Matrix3f)
 
 
 if __name__ == '__main__':

--- a/src/python_pybind11/test/Matrix4_TEST.py
+++ b/src/python_pybind11/test/Matrix4_TEST.py
@@ -14,10 +14,11 @@
 
 import math
 import unittest
-from gz.math8 import Matrix4d
+from gz.math8 import Matrix4d, Matrix4f
 from gz.math8 import Pose3d
 from gz.math8 import Quaterniond
 from gz.math8 import Vector3d
+import test_common
 
 
 class TestMatrix4(unittest.TestCase):
@@ -515,6 +516,9 @@ class TestMatrix4(unittest.TestCase):
                                Vector3d(0, 1, 1)).pose(),
                                Pose3d(1, 1, 1, math.pi/4, 0, math.pi))
 
+    def test_buffer(self):
+        test_common.test_matrix(self, 4, Matrix4d)
+        test_common.test_matrix(self, 4, Matrix4f)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Matrix4_TEST.py
+++ b/src/python_pybind11/test/Matrix4_TEST.py
@@ -18,7 +18,7 @@ from gz.math8 import Matrix4d, Matrix4f
 from gz.math8 import Pose3d
 from gz.math8 import Quaterniond
 from gz.math8 import Vector3d
-import test_common
+import numpy_helpers
 
 
 class TestMatrix4(unittest.TestCase):
@@ -517,8 +517,8 @@ class TestMatrix4(unittest.TestCase):
                                Pose3d(1, 1, 1, math.pi/4, 0, math.pi))
 
     def test_buffer(self):
-        test_common.test_matrix(self, 4, Matrix4d)
-        test_common.test_matrix(self, 4, Matrix4f)
+        numpy_helpers.test_matrix(self, 4, Matrix4d)
+        numpy_helpers.test_matrix(self, 4, Matrix4f)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Matrix6_TEST.py
+++ b/src/python_pybind11/test/Matrix6_TEST.py
@@ -14,7 +14,8 @@
 
 import math
 import unittest
-from gz.math8 import Matrix3d, Matrix6d, Matrix6dCorner
+from gz.math8 import Matrix3d, Matrix6d, Matrix6dCorner, Matrix6f
+import test_common
 
 
 class TestMatrix6(unittest.TestCase):
@@ -253,6 +254,11 @@ class TestMatrix6(unittest.TestCase):
             18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29,
             30, 31, 32, 33, 34, 35))
+
+    def test_buffer(self):
+        test_common.test_matrix(self, 6, Matrix6d)
+        test_common.test_matrix(self, 6, Matrix6f)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Matrix6_TEST.py
+++ b/src/python_pybind11/test/Matrix6_TEST.py
@@ -15,7 +15,7 @@
 import math
 import unittest
 from gz.math8 import Matrix3d, Matrix6d, Matrix6dCorner, Matrix6f
-import test_common
+import numpy_helpers
 
 
 class TestMatrix6(unittest.TestCase):
@@ -256,8 +256,8 @@ class TestMatrix6(unittest.TestCase):
             30, 31, 32, 33, 34, 35))
 
     def test_buffer(self):
-        test_common.test_matrix(self, 6, Matrix6d)
-        test_common.test_matrix(self, 6, Matrix6f)
+        numpy_helpers.test_matrix(self, 6, Matrix6d)
+        numpy_helpers.test_matrix(self, 6, Matrix6f)
 
 
 if __name__ == '__main__':

--- a/src/python_pybind11/test/Vector2_TEST.py
+++ b/src/python_pybind11/test/Vector2_TEST.py
@@ -18,6 +18,7 @@ import unittest
 
 from gz.math8 import Vector2d
 from gz.math8 import Vector2f
+import test_common
 
 
 class TestVector2(unittest.TestCase):
@@ -316,6 +317,11 @@ class TestVector2(unittest.TestCase):
         nanVecF.correct()
         self.assertEqual(Vector2f.ZERO, nanVecF)
         self.assertTrue(nanVecF.is_finite())
+
+    def test_buffer(self):
+        test_common.test_vector(self, 2, Vector2d)
+        test_common.test_vector(self, 2, Vector2f)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Vector2_TEST.py
+++ b/src/python_pybind11/test/Vector2_TEST.py
@@ -18,7 +18,7 @@ import unittest
 
 from gz.math8 import Vector2d
 from gz.math8 import Vector2f
-import test_common
+import numpy_helpers
 
 
 class TestVector2(unittest.TestCase):
@@ -319,8 +319,8 @@ class TestVector2(unittest.TestCase):
         self.assertTrue(nanVecF.is_finite())
 
     def test_buffer(self):
-        test_common.test_vector(self, 2, Vector2d)
-        test_common.test_vector(self, 2, Vector2f)
+        numpy_helpers.test_vector(self, 2, Vector2d)
+        numpy_helpers.test_vector(self, 2, Vector2f)
 
 
 if __name__ == '__main__':

--- a/src/python_pybind11/test/Vector3_TEST.py
+++ b/src/python_pybind11/test/Vector3_TEST.py
@@ -15,6 +15,7 @@
 import copy
 import math
 import unittest
+import test_common
 
 from gz.math8 import Vector3d
 from gz.math8 import Vector3f
@@ -373,6 +374,14 @@ class TestVector3(unittest.TestCase):
         nanVecF.correct()
         self.assertEqual(Vector3f.ZERO, nanVecF)
         self.assertTrue(nanVecF.is_finite())
+
+    def test_buffer(self):
+        test_common.test_vector(self, 3, Vector3d)
+        test_common.test_vector(self, 3, Vector3f)
+
+
+if __name__ == '__main__':
+    unittest.main()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Vector3_TEST.py
+++ b/src/python_pybind11/test/Vector3_TEST.py
@@ -15,7 +15,7 @@
 import copy
 import math
 import unittest
-import test_common
+import numpy_helpers
 
 from gz.math8 import Vector3d
 from gz.math8 import Vector3f
@@ -376,8 +376,8 @@ class TestVector3(unittest.TestCase):
         self.assertTrue(nanVecF.is_finite())
 
     def test_buffer(self):
-        test_common.test_vector(self, 3, Vector3d)
-        test_common.test_vector(self, 3, Vector3f)
+        numpy_helpers.test_vector(self, 3, Vector3d)
+        numpy_helpers.test_vector(self, 3, Vector3f)
 
 
 if __name__ == '__main__':

--- a/src/python_pybind11/test/Vector4_TEST.py
+++ b/src/python_pybind11/test/Vector4_TEST.py
@@ -15,6 +15,7 @@
 import copy
 import math
 import unittest
+import test_common
 
 from gz.math8 import Vector4d
 from gz.math8 import Vector4f
@@ -280,6 +281,10 @@ class TestVector4(unittest.TestCase):
         nanVecF.correct()
         self.assertEqual(Vector4f.ZERO, nanVecF)
         self.assertTrue(nanVecF.is_finite())
+
+    def test_buffer(self):
+        test_common.test_vector(self, 4, Vector4d)
+        test_common.test_vector(self, 4, Vector4f)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Vector4_TEST.py
+++ b/src/python_pybind11/test/Vector4_TEST.py
@@ -15,7 +15,7 @@
 import copy
 import math
 import unittest
-import test_common
+import numpy_helpers
 
 from gz.math8 import Vector4d
 from gz.math8 import Vector4f
@@ -283,8 +283,8 @@ class TestVector4(unittest.TestCase):
         self.assertTrue(nanVecF.is_finite())
 
     def test_buffer(self):
-        test_common.test_vector(self, 4, Vector4d)
-        test_common.test_vector(self, 4, Vector4f)
+        numpy_helpers.test_vector(self, 4, Vector4d)
+        numpy_helpers.test_vector(self, 4, Vector4f)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/numpy_helpers.py
+++ b/src/python_pybind11/test/numpy_helpers.py
@@ -13,7 +13,7 @@ try:
         # Have to cast through bytes for some reason...
         aslist = memoryview(matrix).tolist()
         self.assertEqual(np.array(elements).reshape((size,size)).tolist(), aslist)
-        
+
         v = np.array(matrix, copy=False)
         self.assertEqual(matrix(0,1), 2)
         v[0,1] = 5
@@ -28,7 +28,7 @@ try:
         # Have to cast through bytes for some reason...
         aslist = memoryview(vector).tolist()
         self.assertEqual(elements, aslist)
-        
+
         v = np.array(vector, copy=False)
         self.assertEqual(vector[1], 2)
         v[1] = 5
@@ -38,7 +38,7 @@ try:
 
 except ImportError:
     def test_matrix(self: unittest.TestCase, size:int, cl):
-        pass
+        print("Numpy unavailable. Skipping test")
 
     def test_vector(self: unittest.TestCase, size:int, cl):
-        pass
+        print("Numpy unavailable. Skipping test")

--- a/src/python_pybind11/test/test_common.py
+++ b/src/python_pybind11/test/test_common.py
@@ -1,35 +1,44 @@
 import unittest
-import numpy as np
 
-def test_matrix(self: unittest.TestCase, size:int, cl):
-    elements = list(np.arange(size*size, dtype=float) + 1)
-    matrix = cl(*elements)
+# If numpy is not available, skip these tests
+try:
+    import numpy as np
 
-    self.assertEqual(matrix(1,2), memoryview(matrix)[1,2])
-    self.assertTrue(memoryview(matrix).c_contiguous)
-    # Have to cast through bytes for some reason...
-    aslist = memoryview(matrix).tolist()
-    self.assertEqual(np.array(elements).reshape((size,size)).tolist(), aslist)
-    
-    v = np.array(matrix, copy=False)
-    self.assertEqual(matrix(0,1), 2)
-    v[0,1] = 5
-    self.assertEqual(matrix(0,1), 5) # can mutate origina matrix
+    def test_matrix(self: unittest.TestCase, size:int, cl):
+        elements = list(np.arange(size*size, dtype=float) + 1)
+        matrix = cl(*elements)
 
-def test_vector(self: unittest.TestCase, size:int, cl):
-    elements = list(np.arange(size, dtype=float) + 1)
-    vector = cl(*elements)
+        self.assertEqual(matrix(1,2), memoryview(matrix)[1,2])
+        self.assertTrue(memoryview(matrix).c_contiguous)
+        # Have to cast through bytes for some reason...
+        aslist = memoryview(matrix).tolist()
+        self.assertEqual(np.array(elements).reshape((size,size)).tolist(), aslist)
+        
+        v = np.array(matrix, copy=False)
+        self.assertEqual(matrix(0,1), 2)
+        v[0,1] = 5
+        self.assertEqual(matrix(0,1), 5) # can mutate origina matrix
 
-    self.assertEqual(vector[1], memoryview(vector)[1])
-    self.assertTrue(memoryview(vector).c_contiguous)
-    # Have to cast through bytes for some reason...
-    aslist = memoryview(vector).tolist()
-    self.assertEqual(elements, aslist)
-    
-    v = np.array(vector, copy=False)
-    self.assertEqual(vector[1], 2)
-    v[1] = 5
-    self.assertEqual(vector[1], 5) # can mutate original vector
+    def test_vector(self: unittest.TestCase, size:int, cl):
+        elements = list(np.arange(size, dtype=float) + 1)
+        vector = cl(*elements)
 
-    self.assertEqual(elements, list(elements))
+        self.assertEqual(vector[1], memoryview(vector)[1])
+        self.assertTrue(memoryview(vector).c_contiguous)
+        # Have to cast through bytes for some reason...
+        aslist = memoryview(vector).tolist()
+        self.assertEqual(elements, aslist)
+        
+        v = np.array(vector, copy=False)
+        self.assertEqual(vector[1], 2)
+        v[1] = 5
+        self.assertEqual(vector[1], 5) # can mutate original vector
 
+        self.assertEqual(elements, list(elements))
+
+except ImportError:
+    def test_matrix(self: unittest.TestCase, size:int, cl):
+        pass
+
+    def test_vector(self: unittest.TestCase, size:int, cl):
+        pass

--- a/src/python_pybind11/test/test_common.py
+++ b/src/python_pybind11/test/test_common.py
@@ -1,0 +1,35 @@
+import unittest
+import numpy as np
+
+def test_matrix(self: unittest.TestCase, size:int, cl):
+    elements = list(np.arange(size*size, dtype=float) + 1)
+    matrix = cl(*elements)
+
+    self.assertEqual(matrix(1,2), memoryview(matrix)[1,2])
+    self.assertTrue(memoryview(matrix).c_contiguous)
+    # Have to cast through bytes for some reason...
+    aslist = memoryview(matrix).tolist()
+    self.assertEqual(np.array(elements).reshape((size,size)).tolist(), aslist)
+    
+    v = np.array(matrix, copy=False)
+    self.assertEqual(matrix(0,1), 2)
+    v[0,1] = 5
+    self.assertEqual(matrix(0,1), 5) # can mutate origina matrix
+
+def test_vector(self: unittest.TestCase, size:int, cl):
+    elements = list(np.arange(size, dtype=float) + 1)
+    vector = cl(*elements)
+
+    self.assertEqual(vector[1], memoryview(vector)[1])
+    self.assertTrue(memoryview(vector).c_contiguous)
+    # Have to cast through bytes for some reason...
+    aslist = memoryview(vector).tolist()
+    self.assertEqual(elements, aslist)
+    
+    v = np.array(vector, copy=False)
+    self.assertEqual(vector[1], 2)
+    v[1] = 5
+    self.assertEqual(vector[1], 5) # can mutate original vector
+
+    self.assertEqual(elements, list(elements))
+


### PR DESCRIPTION
This is an extension/takeover of https://github.com/gazebosim/gz-math/pull/498

## Summary

This change enables the buffer_protocol for `VectorX` and `MatrixYxY` so that `memoryiew` and `numpy.array` can be used on them

```
np.array(math7.Vector3())
memoryview(math7.Matrix3d())

list(math7.Vector2d())
>>> math7.Quaterniond().xyzw() # == [0.0, 0.0, 0.0, 1.0]
```
Additionally:
- IndexError is raised on invalid vector __getitem__/__setitem__ access. This way list(vector) works correctly instead of spinning
- A convenience Quaternion.xyzw() -> list is added

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
