### PR TITLE
Disable pybind11 on windows by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,14 @@ option(SKIP_SWIG
       "Skip generating ruby bindings via Swig"
       OFF)
 
+set(skip_pybind11_default_value OFF)
+if (MSVC)
+  set(skip_pybind11_default_value ON)
+endif()
+
 option(SKIP_PYBIND11
       "Skip generating Python bindings via pybind11"
-      OFF)
+      ${skip_pybind11_default_value})
 
 include(CMakeDependentOption)
 cmake_dependent_option(USE_SYSTEM_PATHS_FOR_RUBY_INSTALLATION


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Our CI didn't have `pybind11` installed, so the binding code wasn't being tested. When `pybind11` is actually installed, the MSVC compiler generates  over 120 warnings and all the python related tests fail. The warnings have caused problems downstream (https://github.com/gazebo-release/gz_math6_vendor/pull/4). This PR disabled pybind11 on windows by default until we fix the warnings and test failures. 

Needs #528 


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
