### PR TITLE
Add tests to increase test coverage

### DIFF
--- a/src/Color_TEST.cc
+++ b/src/Color_TEST.cc
@@ -74,6 +74,14 @@ TEST(Color, Color)
   EXPECT_FLOAT_EQ(0.0f, clr0.B());
   EXPECT_FLOAT_EQ(1.0f, clr0.A());
   EXPECT_EQ(clr0.AsRGBA(), 255u);
+
+  auto clrcpy = math::Color(clr0);
+  EXPECT_FLOAT_EQ(0.0f, clrcpy.R());
+  EXPECT_FLOAT_EQ(0.0f, clrcpy.G());
+  EXPECT_FLOAT_EQ(0.0f, clrcpy.B());
+  EXPECT_FLOAT_EQ(1.0f, clrcpy.A());
+  EXPECT_EQ(clrcpy.AsRGBA(), 255u);
+
   clr0.A(0.0);
   EXPECT_EQ(clr0.AsRGBA(), 0u);
 
@@ -256,6 +264,12 @@ TEST(Color, Color)
   EXPECT_TRUE(math::equal(0.1f, clr.G()));
   EXPECT_TRUE(math::equal(0.2f, clr.B()));
   EXPECT_TRUE(math::equal(0.3f, clr.A()));
+
+  clrcpy = math::Color(clr);
+  EXPECT_TRUE(math::equal(0.25f, clrcpy.R()));
+  EXPECT_TRUE(math::equal(0.1f, clrcpy.G()));
+  EXPECT_TRUE(math::equal(0.2f, clrcpy.B()));
+  EXPECT_TRUE(math::equal(0.3f, clrcpy.A()));
 }
 
 

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -115,6 +115,13 @@ TEST(MaterialTest, Accessors)
   }
 
   {
+    Material mat("wood");
+    EXPECT_FALSE(mat.Name().empty());
+    mat.SetName("MyWood");
+    EXPECT_EQ("MyWood", mat.Name());
+  }
+
+  {
     Material material;
     material.SetToNearestDensity(19300.0);
     EXPECT_EQ(MaterialType::TUNGSTEN, material.Type());


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Increases the test coverage by adding tests for uncovered code parts. First I checked the [older branch](https://app.codecov.io/gh/gazebosim/gz-math/blob/ign-math6/src/Color.cc) for `Color.cc` but it shouldn't harm to add it anyway (test the copy constructor). The other test is based on  [`gz-math7`](https://app.codecov.io/gh/gazebosim/gz-math/blob/gz-math7/src/Material.cc) for`Material.cc`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.