### PR TITLE
Fixes for testing in non standard architectures

### DIFF
--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -1006,7 +1006,7 @@ TEST(HelpersTest, AppendToStream)
       << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
 
   math::appendToStream(out, pi);
-#ifdef _WIN32 && !defined(__amd64__) && !defined(__i386__)
+#if defined(_WIN32) && !defined(__amd64__) && !defined(__i386__)
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793");
 #else
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239");
@@ -1016,7 +1016,7 @@ TEST(HelpersTest, AppendToStream)
       << std::setprecision(3);
 
   math::appendToStream(out, pi);
-#ifdef _WIN32 && !defined(__amd64__) && !defined(__i386__)
+#if defined(_WIN32) && !defined(__amd64__) && !defined(__i386__)
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793 3.14");
 #else
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239 3.14");

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -1006,7 +1006,7 @@ TEST(HelpersTest, AppendToStream)
       << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
 
   math::appendToStream(out, pi);
-#ifdef _WIN32
+#ifdef _WIN32 && !defined(__amd64__) && !defined(__i386__)
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793");
 #else
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239");
@@ -1016,7 +1016,7 @@ TEST(HelpersTest, AppendToStream)
       << std::setprecision(3);
 
   math::appendToStream(out, pi);
-#ifdef _WIN32
+#ifdef _WIN32 && !defined(__amd64__) && !defined(__i386__)
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793 3.14");
 #else
   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239 3.14");

--- a/src/Pose_TEST.cc
+++ b/src/Pose_TEST.cc
@@ -181,10 +181,10 @@ TEST(PoseTest, ConstPose)
 /////////////////////////////////////////////////
 TEST(PoseTest, OperatorStreamOut)
 {
-  math::Pose3d p(0.1, 1.2, 2.3, 0.0, 0.1, 1.0);
+  math::Pose3d p(0.1, 1.2, 2.3, 0.2, 0.1, 1.0);
   std::ostringstream stream;
   stream << p;
-  EXPECT_EQ(stream.str(), "0.1 1.2 2.3 0 0.1 1");
+  EXPECT_EQ(stream.str(), "0.1 1.2 2.3 0.2 0.1 1");
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixes for tests in non x32 arches:

 * [Handle non i386/amd4 arches in PI precission](https://github.com/gazebosim/gz-math/commit/1ba09691453699b9fd1cfb39a0d0a548cd062801) 
 * [Avoid to use zero as some arches return negative zero in str](https://github.com/gazebosim/gz-math/commit/eed29f923b62b8a2480af4648af7c1218ecd1ba4)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.