### PR TITLE
Update file tree in README to point out pybind11

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ gz-math
 ├── include/gz/math          Header files.
 ├── src                      Source files and unit tests.
 │   └── graph                Source files for the graph classes.
-│   └── python               SWIG Python interfaces.
+│   └── python_pybind11      Pybind11 Python interfaces.
 │   └── ruby                 SWIG Ruby interfaces.
 ├── eigen3                   Files for Eigen component.
 ├── test


### PR DESCRIPTION

# 🦟 Bug fix


## Summary
A small update to point out we use pybind11 for Python instead of SWIG

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
