### PR TITLE
Update Ubuntu Binary installation since apt-key is deprecated

### DIFF
--- a/tutorials/installation.md
+++ b/tutorials/installation.md
@@ -12,16 +12,19 @@ The Source Installation instructions should be used if you need the very latest 
 # Binary Installation
 
 ## Ubuntu Linux
+First install some necessary tools:
 
-Setup your computer to accept software from
+```bash
+sudo apt-get update
+sudo apt-get install lsb-release wget gnupg
+```
+
+Then, setup your computer to accept software from
 *packages.osrfoundation.org*:
-```
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-```
-
-Setup keys:
-```
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+```bash
+sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+sudo apt-get update
 ```
 
 Install Gazebo Math:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
`apt-key` is [deprecated](https://manpages.debian.org/testing/apt/apt-key.8.en.html). This updates our installation instruction to line up with what we have in https://gazebosim.org/docs/latest/install_ubuntu

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
