### PR TITLE
Fix visiblity for linux: move explicit instanciations to the header file

### DIFF
--- a/include/gz/math/MovingWindowFilter.hh
+++ b/include/gz/math/MovingWindowFilter.hh
@@ -92,7 +92,7 @@ namespace gz
   }
 
 
-/// The template explicit instanciations that does not use fundamental types
+/// The template explicit instantiations that does not use fundamental types
 /// (like Vector*) needs to be placed in this header file.
 template class GZ_MATH_VISIBLE MovingWindowFilter<int>;
 template class GZ_MATH_VISIBLE MovingWindowFilter<float>;

--- a/include/gz/math/MovingWindowFilter.hh
+++ b/include/gz/math/MovingWindowFilter.hh
@@ -91,16 +91,6 @@ namespace gz
     using MovingWindowFilterVector3d = MovingWindowFilter<Vector3d>;
   }
 
-
-/// The template explicit instantiations that does not use fundamental types
-/// (like Vector*) needs to be placed in this header file.
-template class GZ_MATH_VISIBLE MovingWindowFilter<int>;
-template class GZ_MATH_VISIBLE MovingWindowFilter<float>;
-template class GZ_MATH_VISIBLE MovingWindowFilter<double>;
-template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3i>;
-template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3f>;
-template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3d>;
-
   }  // namespace math
 }  // namespace gz
 #endif

--- a/include/gz/math/MovingWindowFilter.hh
+++ b/include/gz/math/MovingWindowFilter.hh
@@ -90,6 +90,17 @@ namespace gz
     using MovingWindowFilterVector3f = MovingWindowFilter<Vector3f>;
     using MovingWindowFilterVector3d = MovingWindowFilter<Vector3d>;
   }
+
+
+/// The template explicit instanciations that does not use fundamental types
+/// (like Vector*) needs to be placed in this header file.
+template class GZ_MATH_VISIBLE MovingWindowFilter<int>;
+template class GZ_MATH_VISIBLE MovingWindowFilter<float>;
+template class GZ_MATH_VISIBLE MovingWindowFilter<double>;
+template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3i>;
+template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3f>;
+template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3d>;
+
   }  // namespace math
 }  // namespace gz
 #endif

--- a/src/MovingWindowFilter.cc
+++ b/src/MovingWindowFilter.cc
@@ -137,13 +137,6 @@ MovingWindowFilter<gz::math::Vector3d>::Value() const
   return value;
 }
 
-template class MovingWindowFilter<int>;
-template class MovingWindowFilter<float>;
-template class MovingWindowFilter<double>;
-template class MovingWindowFilter<gz::math::Vector3i>;
-template class MovingWindowFilter<gz::math::Vector3f>;
-template class MovingWindowFilter<gz::math::Vector3d>;
-
 }
 }  // namespace math
 }  // namespace gz

--- a/src/MovingWindowFilter.cc
+++ b/src/MovingWindowFilter.cc
@@ -15,6 +15,7 @@
  *
  */
 
+#include "gz/math/Export.hh"
 #include "gz/math/MovingWindowFilter.hh"
 #include "gz/math/Vector3.hh"
 
@@ -136,6 +137,13 @@ MovingWindowFilter<gz::math::Vector3d>::Value() const
   auto value = this->sum / this->samples;
   return value;
 }
+
+ template class MovingWindowFilter<int>;
+ template class MovingWindowFilter<float>;
+ template class MovingWindowFilter<double>;
+ template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3i>;
+ template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3f>;
+ template class GZ_MATH_VISIBLE MovingWindowFilter<gz::math::Vector3d>;
 
 }
 }  // namespace math


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

GCC was not happy with the use of a header only types in the explicit instantiations in order to generate the symbols in the library.  Fixed by moving them to the header.

Part of the changes for https://github.com/gazebosim/gz-cmake/pull/392
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.