### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,6 @@ set(FAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/fake/install")
 # Configure the build
 #============================================================================
 gz_configure_build(QUIT_IF_BUILD_ERRORS
-  HIDE_SYMBOLS_BY_DEFAULT
   COMPONENTS eigen3)
 
 


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166