### PR TITLE
Enable 24.04 CI, remove distutils dependency

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -2,7 +2,6 @@ libeigen3-dev
 libgz-cmake4-dev
 libgz-utils3-dev
 libpython3-dev
-python3-distutils
 python3-pybind11
 python3-pytest
 ruby-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Compile and test
         id: ci
-        uses: gazebo-tooling/action-gz-ci@noble
+        uses: gazebo-tooling/action-gz-ci@scpeters/noble_pip_break_system_packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,12 @@ jobs:
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Compile and test
         id: ci
-        uses: gazebo-tooling/action-gz-ci@scpeters/noble_pip_break_system_packages
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(gz-math-examples)
 

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -73,18 +73,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
-  if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-  from distutils import sysconfig as sc
-  print(sc.get_python_lib(plat_specific=True))"
-      OUTPUT_VARIABLE Python3_SITEARCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  else()
-    # Get install variable from Python3 module
-    # Python3_SITEARCH is available from 3.12 on, workaround if needed:
-    find_package(Python3 COMPONENTS Interpreter)
-  endif()
+  # Get install variable from Python3 module
+  # Python3_SITEARCH is available from 3.12 on, workaround if needed:
+  find_package(Python3 COMPONENTS Interpreter)
 
   if(USE_DIST_PACKAGES_FOR_PYTHON)
     string(REPLACE "site-packages" "dist-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITEARCH})

--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -44,11 +44,7 @@ if (RUBY_FOUND)
 
   # Create the ruby library
   set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/ruby")
-  if(CMAKE_VERSION VERSION_GREATER 3.8.0)
-    SWIG_ADD_LIBRARY(${SWIG_RB_LIB} LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
-  else()
-    SWIG_ADD_MODULE(${SWIG_RB_LIB} ruby ruby.i ${swig_i_files})
-  endif()
+  SWIG_ADD_LIBRARY(${SWIG_RB_LIB} LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
 
   # Suppress warnings on SWIG-generated files
   target_compile_options(${SWIG_RB_LIB} PRIVATE


### PR DESCRIPTION
# 🎉 New feature

Attempting to enable CI on 24.04

## Summary

The `python3-distutils` package is not available on 24.04, but we only use it in a codepath for old versions of cmake. Since we are already requiring cmake 3.22.1 in gz-cmake4, we can require that version in gz-math8 as well and remove code for old versions of cmake.

This isn't quite working yet due to an error using `pip` with python 3.12 on Noble.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
