### PR TITLE
Find python directly instead of using GzPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,16 +99,14 @@ endif()
 if (SKIP_PYBIND11)
   message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
 else()
-  include(GzPython)
-  find_package(PythonLibs QUIET)
-  if (NOT PYTHONLIBS_FOUND)
-    GZ_BUILD_WARNING("Python is missing: Python interfaces are disabled.")
-    message (STATUS "Searching for Python - not found.")
+  find_package(Python3 REQUIRED
+    COMPONENTS Interpreter
+    OPTIONAL_COMPONENTS Development
+  )
+  if (NOT Python3_Development_FOUND)
+    GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
   else()
-    message (STATUS "Searching for Python - found version ${PYTHONLIBS_VERSION_STRING}.")
-
     set(PYBIND11_PYTHON_VERSION 3)
-    find_package(Python3 QUIET COMPONENTS Interpreter Development)
     find_package(pybind11 2.2 QUIET)
 
     if (${pybind11_FOUND})

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -73,9 +73,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
-  # Get install variable from Python3 module
-  # Python3_SITEARCH is available from 3.12 on, workaround if needed:
-  find_package(Python3 COMPONENTS Interpreter)
+  if(NOT Python3_SITEARCH)
+    # Get install variable from Python3 module
+    find_package(Python3 COMPONENTS Interpreter)
+  endif()
 
   if(USE_DIST_PACKAGES_FOR_PYTHON)
     string(REPLACE "site-packages" "dist-packages" GZ_PYTHON_INSTALL_PATH ${Python3_SITEARCH})


### PR DESCRIPTION
# 🎉 New feature

Part of gazebosim/gz-cmake#350.

## Summary

I suggested in https://github.com/gazebosim/gz-cmake/issues/350#issuecomment-1907453341 that we find python directly so that GzPython can be deprecated, and this is a step towards that goal.

## Test it

* Compile and run tests and verify that the check_test_ran.py script still runs.
* Compile and run python tests and verify that they pass.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
