### PR TITLE
Enable 24.04 CI on harmonic

### DIFF
--- a/.github/ci/packages-focal.apt
+++ b/.github/ci/packages-focal.apt
@@ -1,0 +1,1 @@
+python3-distutils

--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,1 +1,0 @@
-python3-distutils

--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,0 +1,1 @@
+python3-distutils

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -2,7 +2,6 @@ libeigen3-dev
 libgz-cmake3-dev
 libgz-utils2-dev
 libpython3-dev
-python3-distutils
 python3-pybind11
 python3-pytest
 ruby-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,12 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -44,11 +44,7 @@ if (RUBY_FOUND)
 
   # Create the ruby library
   set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/ruby")
-  if(CMAKE_VERSION VERSION_GREATER 3.8.0)
-    SWIG_ADD_LIBRARY(${SWIG_RB_LIB} LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
-  else()
-    SWIG_ADD_MODULE(${SWIG_RB_LIB} ruby ruby.i ${swig_i_files})
-  endif()
+  SWIG_ADD_LIBRARY(${SWIG_RB_LIB} LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
 
   # Suppress warnings on SWIG-generated files
   target_compile_options(${SWIG_RB_LIB} PRIVATE


### PR DESCRIPTION
# 🎉 New feature

Attempting to enable CI on 24.04 for Harmonic (partial backport of #587)

## Summary

The python3-distutils package is not available on 24.04, but we only use it in a codepath for old versions of cmake. Since 24.04 has a new enough version of cmake, that package is moved from the generic `package.apt` file to distro-specific `packages-focal.apt` and `packages-jammy.apt` files.

* Don't install python3-distutils on 24.04
* Remove old ruby cmake code

## Test it

Observe CI results.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
