### PR TITLE
Add Cone as a primitive parametric shape.

### DIFF
--- a/include/gz/math/Cone.hh
+++ b/include/gz/math/Cone.hh
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_MATH_CONE_HH_
+#define GZ_MATH_CONE_HH_
+
+#include <optional>
+#include "gz/math/MassMatrix3.hh"
+#include "gz/math/Material.hh"
+#include "gz/math/Quaternion.hh"
+
+namespace gz
+{
+  namespace math
+  {
+    // Foward declarations
+    class ConePrivate;
+
+    // Inline bracket to help doxygen filtering.
+    inline namespace GZ_MATH_VERSION_NAMESPACE {
+    //
+    /// \class Cone Cone.hh gz/math/Cone.hh
+    /// \brief A representation of a cone.
+    ///
+    /// The cone class supports defining a cone with a radius,
+    /// length, rotational offset, and material properties. Radius and
+    /// length are in meters. See Material for more on material properties.
+    /// By default, a cone's length is aligned with the Z axis where the base
+    /// of the cone is proximal to the origin and vertex points in positive Z.
+    /// The rotational offset encodes a rotation from the z axis.
+    template<typename Precision>
+    class Cone
+    {
+      /// \brief Default constructor. The default radius and length are both
+      /// zero. The default rotational offset is
+      /// Quaternion<Precision>::Identity.
+      public: Cone() = default;
+
+      /// \brief Construct a cone with a length, radius, and optionally
+      /// a rotational offset.
+      /// \param[in] _length Length of the cone.
+      /// \param[in] _radius Radius of the cone.
+      /// \param[in] _rotOffset Rotational offset of the cone.
+      public: Cone(const Precision _length, const Precision _radius,
+                   const Quaternion<Precision> &_rotOffset =
+                   Quaternion<Precision>::Identity);
+
+      /// \brief Construct a cone with a length, radius, material and
+      /// optionally a rotational offset.
+      /// \param[in] _length Length of the cone.
+      /// \param[in] _radius Radius of the cone.
+      /// \param[in] _mat Material property for the cone.
+      /// \param[in] _rotOffset Rotational offset of the cone.
+      public: Cone(const Precision _length, const Precision _radius,
+                   const Material &_mat,
+                   const Quaternion<Precision> &_rotOffset =
+                   Quaternion<Precision>::Identity);
+
+      /// \brief Get the radius in meters.
+      /// \return The radius of the cone in meters.
+      public: Precision Radius() const;
+
+      /// \brief Set the radius in meters.
+      /// \param[in] _radius The radius of the cone in meters.
+      public: void SetRadius(const Precision _radius);
+
+      /// \brief Get the length in meters.
+      /// \return The length of the cone in meters.
+      public: Precision Length() const;
+
+      /// \brief Set the length in meters.
+      /// \param[in] _length The length of the cone in meters.
+      public: void SetLength(const Precision _length);
+
+      /// \brief Get the rotational offset. By default, a cone's length
+      /// is aligned with the Z axis. The rotational offset encodes
+      /// a rotation from the z axis.
+      /// \return The cone's rotational offset.
+      /// \sa void SetRotationalOffset(const Quaternion<Precision> &_rot)
+      public: Quaternion<Precision> RotationalOffset() const;
+
+      /// \brief Set the rotation offset.
+      /// \param[in] _rotOffset rotational offset quaternion.
+      /// See Quaternion<Precision> RotationalOffset() for details on the
+      /// rotational offset.
+      /// \sa Quaternion<Precision> RotationalOffset() const
+      public: void SetRotationalOffset(
+                  const Quaternion<Precision> &_rotOffset);
+
+      /// \brief Get the material associated with this cone.
+      /// \return The material assigned to this cone
+      public: const Material &Mat() const;
+
+      /// \brief Set the material associated with this cone.
+      /// \param[in] _mat The material assigned to this cone
+      public: void SetMat(const Material &_mat);
+
+      /// \brief Get the mass matrix for this cone. This function
+      /// is only meaningful if the cone's radius, length, and material
+      /// have been set. Optionally, set the rotational offset.
+      /// \param[out] _massMat The computed mass matrix will be stored
+      /// here.
+      /// \return False if computation of the mass matrix failed, which
+      /// could be due to an invalid radius (<=0), length (<=0), or density
+      /// (<=0).
+      public: bool MassMatrix(MassMatrix3d &_massMat) const;
+
+      /// \brief Get the mass matrix for this cone. This function
+      /// is only meaningful if the cone's radius, length, and material
+      /// have been set. Optionally, set the rotational offset.
+      /// \return The computed mass matrix if parameters are valid
+      /// (radius > 0), (length > 0) and (density > 0). Otherwise
+      /// std::nullopt is returned.
+      public: std::optional< MassMatrix3<Precision> > MassMatrix() const;
+
+      /// \brief Check if this cone is equal to the provided cone.
+      /// Radius, length, and material properties will be checked.
+      public: bool operator==(const Cone &_cone) const;
+
+      /// \brief Get the volume of the cone in m^3.
+      /// \return Volume of the cone in m^3.
+      public: Precision Volume() const;
+
+      /// \brief Compute the cone's density given a mass value. The
+      /// cone is assumed to be solid with uniform density. This
+      /// function requires the cone's radius and length to be set to
+      /// values greater than zero. The Material of the cone is ignored.
+      /// \param[in] _mass Mass of the cone, in kg. This value should be
+      /// greater than zero.
+      /// \return Density of the cone in kg/m^3. A negative value is
+      /// returned if radius, length or _mass is <= 0.
+      public: Precision DensityFromMass(const Precision _mass) const;
+
+      /// \brief Set the density of this cone based on a mass value.
+      /// Density is computed using
+      /// Precision DensityFromMass(const Precision _mass) const. The
+      /// cone is assumed to be solid with uniform density. This
+      /// function requires the cone's radius and length to be set to
+      /// values greater than zero. The existing Material density value is
+      /// overwritten only if the return value from this true.
+      /// \param[in] _mass Mass of the cone, in kg. This value should be
+      /// greater than zero.
+      /// \return True if the density was set. False is returned if the
+      /// cone's radius, length, or the _mass value are <= 0.
+      /// \sa Precision DensityFromMass(const Precision _mass) const
+      public: bool SetDensityFromMass(const Precision _mass);
+
+      /// \brief Radius of the cone.
+      private: Precision radius = 0.0;
+
+      /// \brief Length of the cone.
+      private: Precision length = 0.0;
+
+      /// \brief the cone's material.
+      private: Material material;
+
+      /// \brief Rotational offset.
+      private: Quaternion<Precision> rotOffset =
+               Quaternion<Precision>::Identity;
+    };
+
+    /// \typedef Cone<int> Conei
+    /// \brief Cone with integer precision.
+    typedef Cone<int> Conei;
+
+    /// \typedef Cone<double> Coned
+    /// \brief Cone with double precision.
+    typedef Cone<double> Coned;
+
+    /// \typedef Cone<float> Conef
+    /// \brief Cone with float precision.
+    typedef Cone<float> Conef;
+    }
+  }
+}
+#include "gz/math/detail/Cone.hh"
+
+#endif

--- a/include/gz/math/Helpers.hh
+++ b/include/gz/math/Helpers.hh
@@ -67,6 +67,11 @@ constexpr T IGN_MASSMATRIX3_DEFAULT_TOLERANCE = T(10);
 /// \param[in] _radius Sphere radius
 #define GZ_SPHERE_VOLUME(_radius) (4.0*GZ_PI*std::pow(_radius, 3)/3.0)
 
+/// \brief Compute cone volume
+/// \param[in] _r Cone base radius
+/// \param[in] _l Cone length
+#define GZ_CONE_VOLUME(_r, _l) (_l * GZ_PI * std::pow(_r, 2) / 3.0)
+
 /// \brief Compute cylinder volume
 /// \param[in] _r Cylinder base radius
 /// \param[in] _l Cylinder length

--- a/include/gz/math/detail/Cone.hh
+++ b/include/gz/math/detail/Cone.hh
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_MATH_DETAIL_CONE_HH_
+#define GZ_MATH_DETAIL_CONE_HH_
+
+#include <optional>
+
+namespace gz
+{
+namespace math
+{
+
+//////////////////////////////////////////////////
+template<typename T>
+Cone<T>::Cone(const T _length, const T _radius,
+    const Quaternion<T> &_rotOffset)
+{
+  this->length = _length;
+  this->radius = _radius;
+  this->rotOffset = _rotOffset;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+Cone<T>::Cone(const T _length, const T _radius,
+    const Material &_mat, const Quaternion<T> &_rotOffset)
+{
+  this->length = _length;
+  this->radius = _radius;
+  this->material = _mat;
+  this->rotOffset = _rotOffset;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Cone<T>::Radius() const
+{
+  return this->radius;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+void Cone<T>::SetRadius(const T _radius)
+{
+  this->radius = _radius;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Cone<T>::Length() const
+{
+  return this->length;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+void Cone<T>::SetLength(const T _length)
+{
+  this->length = _length;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+Quaternion<T> Cone<T>::RotationalOffset() const
+{
+  return this->rotOffset;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+void Cone<T>::SetRotationalOffset(const Quaternion<T> &_rotOffset)
+{
+  this->rotOffset = _rotOffset;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+const Material &Cone<T>::Mat() const
+{
+  return this->material;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+void Cone<T>::SetMat(const Material &_mat)
+{
+  this->material = _mat;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+bool Cone<T>::operator==(const Cone &_cone) const
+{
+  return equal(this->radius, _cone.Radius()) &&
+    equal(this->length, _cone.Length()) &&
+    this->material == _cone.Mat();
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+bool Cone<T>::MassMatrix(MassMatrix3d &_massMat) const
+{
+  return _massMat.SetFromConeZ(
+      this->material, this->length,
+      this->radius, this->rotOffset);
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+std::optional < MassMatrix3<T> > Cone<T>::MassMatrix() const
+{
+  gz::math::MassMatrix3<T> _massMat;
+
+  if(!_massMat.SetFromConeZ(
+      this->material, this->length,
+      this->radius, this->rotOffset))
+  {
+    return std::nullopt;
+  }
+  else
+  {
+    return std::make_optional(_massMat);
+  }
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Cone<T>::Volume() const
+{
+  return GZ_PI * std::pow(this->radius, 2) *
+         this->length / 3.0;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+bool Cone<T>::SetDensityFromMass(const T _mass)
+{
+  T newDensity = this->DensityFromMass(_mass);
+  if (newDensity > 0)
+    this->material.SetDensity(newDensity);
+  return newDensity > 0;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Cone<T>::DensityFromMass(const T _mass) const
+{
+  if (this->radius <= 0 || this->length <=0 || _mass <= 0)
+    return -1.0;
+
+  return _mass / this->Volume();
+}
+
+}  // namespace math
+}  // namespace gz
+#endif

--- a/src/Cone_TEST.cc
+++ b/src/Cone_TEST.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "gz/math/Cone.hh"
+
+using namespace gz;
+
+/////////////////////////////////////////////////
+TEST(ConeTest, Constructor)
+{
+  // Default constructor
+  {
+    math::Coned cone;
+    EXPECT_DOUBLE_EQ(0.0, cone.Length());
+    EXPECT_DOUBLE_EQ(0.0, cone.Radius());
+    EXPECT_EQ(math::Quaterniond::Identity, cone.RotationalOffset());
+    EXPECT_EQ(math::Material(), cone.Mat());
+
+    math::Coned cone2;
+    EXPECT_EQ(cone, cone2);
+  }
+
+  // Length and radius constructor
+  {
+    math::Coned cone(1.0, 2.0);
+    EXPECT_DOUBLE_EQ(1.0, cone.Length());
+    EXPECT_DOUBLE_EQ(2.0, cone.Radius());
+    EXPECT_EQ(math::Quaterniond::Identity, cone.RotationalOffset());
+    EXPECT_EQ(math::Material(), cone.Mat());
+
+    math::Coned cone2(1.0, 2.0);
+    EXPECT_EQ(cone, cone2);
+  }
+
+  // Length, radius, and rot constructor
+  {
+    math::Coned cone(1.0, 2.0, math::Quaterniond(0.1, 0.2, 0.3));
+    EXPECT_DOUBLE_EQ(1.0, cone.Length());
+    EXPECT_DOUBLE_EQ(2.0, cone.Radius());
+    EXPECT_EQ(math::Quaterniond(0.1, 0.2, 0.3),
+        cone.RotationalOffset());
+    EXPECT_EQ(math::Material(), cone.Mat());
+
+    math::Coned cone2(1.0, 2.0, math::Quaterniond(0.1, 0.2, 0.3));
+    EXPECT_EQ(cone, cone2);
+  }
+
+  // Length, radius, mat and rot constructor
+  {
+    math::Coned cone(1.0, 2.0,
+        math::Material(math::MaterialType::WOOD),
+        math::Quaterniond(0.1, 0.2, 0.3));
+    EXPECT_DOUBLE_EQ(1.0, cone.Length());
+    EXPECT_DOUBLE_EQ(2.0, cone.Radius());
+    EXPECT_EQ(math::Quaterniond(0.1, 0.2, 0.3),
+        cone.RotationalOffset());
+    EXPECT_EQ(math::Material(math::MaterialType::WOOD), cone.Mat());
+
+    math::Coned cone2(1.0, 2.0,
+        math::Material(math::MaterialType::WOOD),
+        math::Quaterniond(0.1, 0.2, 0.3));
+    EXPECT_EQ(cone, cone2);
+  }
+}
+
+//////////////////////////////////////////////////
+TEST(ConeTest, Mutators)
+{
+  math::Coned cone;
+  EXPECT_DOUBLE_EQ(0.0, cone.Length());
+  EXPECT_DOUBLE_EQ(0.0, cone.Radius());
+  EXPECT_EQ(math::Quaterniond::Identity, cone.RotationalOffset());
+  EXPECT_EQ(math::Material(), cone.Mat());
+
+  cone.SetLength(100.1);
+  cone.SetRadius(.123);
+  cone.SetRotationalOffset(math::Quaterniond(1.2, 2.3, 3.4));
+  cone.SetMat(math::Material(math::MaterialType::PINE));
+
+  EXPECT_DOUBLE_EQ(100.1, cone.Length());
+  EXPECT_DOUBLE_EQ(.123, cone.Radius());
+  EXPECT_EQ(math::Quaterniond(1.2, 2.3, 3.4),
+    cone.RotationalOffset());
+  EXPECT_EQ(math::Material(math::MaterialType::PINE), cone.Mat());
+}
+
+//////////////////////////////////////////////////
+TEST(ConeTest, VolumeAndDensity)
+{
+  double mass = 1.0;
+  math::Coned cone(1.0, 0.001);
+  double expectedVolume = (GZ_PI * std::pow(0.001, 2) * 1.0 / 3.0);
+  EXPECT_DOUBLE_EQ(expectedVolume, cone.Volume());
+
+  double expectedDensity = mass / expectedVolume;
+  EXPECT_DOUBLE_EQ(expectedDensity, cone.DensityFromMass(mass));
+
+  // Bad density
+  math::Coned cone2;
+  EXPECT_GT(0.0, cone2.DensityFromMass(mass));
+}
+
+//////////////////////////////////////////////////
+TEST(ConeTest, Mass)
+{
+  double mass = 2.0;
+  double l = 2.0;
+  double r = 0.1;
+  math::Coned cone(l, r);
+  cone.SetDensityFromMass(mass);
+
+  math::MassMatrix3d massMat;
+  double ixxIyy = (3.0/80.0) * mass * (4*r*r + l*l);
+  double izz = (3.0/10.0) * mass * r * r;
+
+  math::MassMatrix3d expectedMassMat;
+  expectedMassMat.SetInertiaMatrix(ixxIyy, ixxIyy, izz, 0.0, 0.0, 0.0);
+  expectedMassMat.SetMass(mass);
+
+  cone.MassMatrix(massMat);
+  EXPECT_EQ(expectedMassMat, massMat);
+  EXPECT_DOUBLE_EQ(expectedMassMat.Mass(), massMat.Mass());
+
+  auto massMatOpt = cone.MassMatrix();
+  ASSERT_NE(std::nullopt, massMatOpt);
+  EXPECT_EQ(expectedMassMat, *massMatOpt);
+  EXPECT_EQ(expectedMassMat.DiagonalMoments(), massMatOpt->DiagonalMoments());
+  EXPECT_DOUBLE_EQ(expectedMassMat.Mass(), massMatOpt->Mass());
+}

--- a/src/Helpers.i
+++ b/src/Helpers.i
@@ -38,6 +38,7 @@ constexpr T IGN_MASSMATRIX3_DEFAULT_TOLERANCE = T(10);
 #define GZ_SQRT2 1.41421356237309504880
 
 #define GZ_SPHERE_VOLUME(_radius) (4.0 * GZ_PI * std::pow(_radius, 3)/3.0)
+#define GZ_CONE_VOLUME(_r, _l) (_l * GZ_PI * std::pow(_r, 2) / 3.0)
 #define GZ_CYLINDER_VOLUME(_r, _l) (_l * GZ_PI * std::pow(_r, 2))
 #define GZ_BOX_VOLUME(_x, _y, _z) (_x *_y * _z)
 #define GZ_BOX_VOLUME_V(_v) (_v.X() *_v.Y() * _v.Z())
@@ -50,6 +51,7 @@ constexpr T IGN_MASSMATRIX3_DEFAULT_TOLERANCE = T(10);
 
 // TODO(CH3): Deprecated. Remove on tock.
 #define IGN_SPHERE_VOLUME(_radius) GZ_SPHERE_VOLUME(_radius)
+#define IGN_CONE_VOLUME(_r, _l) GZ_CONE_VOLUME(_r, _l)
 #define IGN_CYLINDER_VOLUME(_r, _l) GZ_CYLINDER_VOLUME(_r, _l)
 #define IGN_BOX_VOLUME(_x, _y, _z) GZ_BOX_VOLUME(_x, _y, _z)
 #define IGN_BOX_VOLUME_V(_v) GZ_BOX_VOLUME_V(_v)

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -429,6 +429,9 @@ TEST(HelpersTest, Volume)
   EXPECT_DOUBLE_EQ(GZ_SPHERE_VOLUME(0.1), 4.0*GZ_PI*std::pow(.1, 3)/3.0);
   EXPECT_DOUBLE_EQ(GZ_SPHERE_VOLUME(-1.1), 4.0*GZ_PI*std::pow(-1.1, 3)/3.0);
 
+  EXPECT_DOUBLE_EQ(GZ_CONE_VOLUME(0.5, 2.0), 2 * GZ_PI * std::pow(.5, 2) / 3.0);
+  EXPECT_DOUBLE_EQ(GZ_CONE_VOLUME(1, -1), -1 * GZ_PI * std::pow(1, 2) / 3.0);
+
   EXPECT_DOUBLE_EQ(GZ_CYLINDER_VOLUME(0.5, 2.0), 2 * GZ_PI * std::pow(.5, 2));
   EXPECT_DOUBLE_EQ(GZ_CYLINDER_VOLUME(1, -1), -1 * GZ_PI * std::pow(1, 2));
 

--- a/src/MassMatrix3_TEST.cc
+++ b/src/MassMatrix3_TEST.cc
@@ -832,6 +832,57 @@ TEST(MassMatrix3dTest, EquivalentBox)
 }
 
 /////////////////////////////////////////////////
+TEST(MassMatrix3dTest, SetFromConeZ)
+{
+  const math::Quaterniond q0 = math::Quaterniond::Identity;
+
+  // Default mass matrix with non-positive inertia
+  {
+    math::MassMatrix3d m;
+
+    // input is all zeros, so SetFromConeZ should fail
+    EXPECT_FALSE(m.SetFromConeZ(0, 0, 0, q0));
+    EXPECT_FALSE(m.SetFromConeZ(0, 0, q0));
+
+    // even if some parameters are valid, none should be set if they
+    // are not all valid
+    EXPECT_FALSE(m.SetFromConeZ(1, 0, 0, q0));
+    EXPECT_FALSE(m.SetFromConeZ(1, 1, 0, q0));
+    EXPECT_FALSE(m.SetFromConeZ(1, 0, 1, q0));
+    EXPECT_DOUBLE_EQ(m.Mass(), 0.0);
+  }
+
+  // unit cone with mass 1.0
+  {
+    const double mass = 1.0;
+    const double length = 1.0;
+    const double radius = 0.5;
+    math::MassMatrix3d m;
+    EXPECT_TRUE(m.SetFromConeZ(mass, length, radius, q0));
+
+    double ixx = (3.0 / 80.0) * mass * (4.0 * std::pow(radius, 2) +
+                  std::pow(length, 2));
+    double iyy = ixx;
+    double izz = (3.0 / 10.0) * mass * std::pow(radius, 2);
+    const math::Vector3d ixxyyzz(ixx, iyy, izz);
+    EXPECT_EQ(m.DiagonalMoments(), ixxyyzz);
+    EXPECT_EQ(m.OffDiagonalMoments(), math::Vector3d::Zero);
+
+    double density = mass / (GZ_PI * radius * radius * length / 3.0);
+    math::Material mat(density);
+    EXPECT_DOUBLE_EQ(density, mat.Density());
+    math::MassMatrix3d m1;
+    EXPECT_FALSE(m1.SetFromConeZ(math::Material(0), length, radius));
+    EXPECT_TRUE(m1.SetFromConeZ(mat, length, radius));
+    EXPECT_EQ(m, m1);
+
+    // double the length and radius
+    EXPECT_TRUE(m.SetFromConeZ(mass, 2*length, 2*radius, q0));
+    EXPECT_EQ(m.DiagonalMoments(), 4*ixxyyzz);
+  }
+}
+
+/////////////////////////////////////////////////
 TEST(MassMatrix3dTest, SetFromCylinderZ)
 {
   const math::Quaterniond q0 = math::Quaterniond::Identity;

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -129,6 +129,7 @@ if (BUILD_TESTING)
     Box_TEST
     Capsule_TEST
     Color_TEST
+    Cone_TEST
     Cylinder_TEST
     DiffDriveOdometry_TEST
     Ellipsoid_TEST

--- a/src/python_pybind11/src/Cone.hh
+++ b/src/python_pybind11/src/Cone.hh
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GZ_MATH_PYTHON__CONE_HH_
+#define GZ_MATH_PYTHON__CONE_HH_
+
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include <gz/math/Cone.hh>
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace gz
+{
+namespace math
+{
+namespace python
+{
+/// Define a pybind11 wrapper for a gz::math::Cone
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+template<typename T>
+void defineMathCone(py::module &m, const std::string &typestr)
+{
+
+  using Class = gz::math::Cone<T>;
+  std::string pyclass_name = typestr;
+  py::class_<Class>(m,
+                    pyclass_name.c_str(),
+                    py::buffer_protocol(),
+                    py::dynamic_attr())
+    .def(py::init<>())
+    .def(py::init<const T, const T,
+                  const gz::math::Quaternion<T>&>(),
+         py::arg("_length") = 0,
+         py::arg("_radius") = 0,
+         py::arg("_rotOffset") = gz::math::Quaternion<T>::Identity)
+    .def(py::init<const T, const T,
+                  const gz::math::Material&,
+                  const gz::math::Quaternion<T>&>(),
+         py::arg("_length") = 0,
+         py::arg("_radius") = 0,
+         py::arg("_material") = gz::math::Material(),
+         py::arg("_rotOffset") = gz::math::Quaternion<T>::Identity)
+    .def(py::self == py::self)
+    .def("radius",
+         &Class::Radius,
+         "Get the radius in meters.")
+    .def("set_radius",
+         &Class::SetRadius,
+         "Set the radius in meters.")
+    .def("length",
+         &Class::Length,
+         "Get the length in meters.")
+    .def("set_length",
+         &Class::SetLength,
+         "Set the length in meters.")
+    .def("rotational_offset",
+         &Class::RotationalOffset,
+         "Get the rotation offset.")
+    .def("set_rotational_offset",
+         &Class::SetRotationalOffset,
+         "Set the rotation offset.")
+    .def("mat",
+         &Class::Mat,
+         "Get the material associated with this box.")
+    .def("set_mat",
+         &Class::SetMat,
+         "Set the material associated with this box.")
+    .def("volume",
+         &Class::Volume,
+         "Get the volume of the box in m^3.")
+    .def("density_from_mass",
+         &Class::DensityFromMass,
+         "Compute the box's density given a mass value.")
+    .def("set_density_from_mass",
+         &Class::SetDensityFromMass,
+         "Set the density of this box based on a mass value.")
+     .def("mass_matrix",
+          py::overload_cast<>(&Class::MassMatrix, py::const_),
+          "Get the mass matrix for this box. This function "
+          "is only meaningful if the box's size and material "
+          "have been set.")
+     .def("mass_matrix",
+          py::overload_cast<gz::math::MassMatrix3<T>&>
+          (&Class::MassMatrix, py::const_),
+          "Get the mass matrix for this box. This function "
+          "is only meaningful if the box's size and material "
+          "have been set.")
+    .def("__copy__", [](const Class &self) {
+      return Class(self);
+    })
+    .def("__deepcopy__", [](const Class &self, py::dict) {
+      return Class(self);
+    }, "memo"_a);
+}
+
+}  // namespace python
+}  // namespace math
+}  // namespace gz
+
+#endif  // GZ_MATH_PYTHON__CONE_HH_

--- a/src/python_pybind11/src/Helpers.cc
+++ b/src/python_pybind11/src/Helpers.cc
@@ -41,6 +41,15 @@ float SphereVolume(const float _radius)
   return GZ_SPHERE_VOLUME(_radius);
 }
 
+/// \brief Compute cone volume
+/// \param[in] _r Cone base radius
+/// \param[in] _l Cone length
+/// \return cone volume
+float ConeVolume(const float _r, const float _l)
+{
+  return GZ_CONE_VOLUME(_r, _l);
+}
+
 /// \brief Compute cylinder volume
 /// \param[in] _r Cylinder base radius
 /// \param[in] _l Cylinder length
@@ -75,6 +84,14 @@ float SphereVolumeDeprecated(const float _radius)
             << "Please use gz_sphere_volume instead"
             << std::endl;
   return SphereVolume(_radius);
+}
+
+float ConeVolumeDeprecated(const float _r, const float _l)
+{
+  std::cerr << "ign_cone_volume is deprecated. "
+            << "Please use gz_cone_volume instead"
+            << std::endl;
+  return ConeVolume(_r, _l);
 }
 
 float CylinderVolumeDeprecated(const float _r, const float _l)
@@ -205,6 +222,9 @@ void defineMathHelpers(py::module &m)
    .def("gz_sphere_volume",
         &SphereVolume,
         "Compute sphere volume")
+   .def("gz_cone_volume",
+        &ConeVolume,
+        "Compute cone volume")
    .def("gz_cylinder_volume",
         &CylinderVolume,
         "Compute cylinder volume")
@@ -219,6 +239,9 @@ void defineMathHelpers(py::module &m)
    .def("ign_sphere_volume",
         &SphereVolumeDeprecated,
         "[Deprecated] Compute sphere volume")
+   .def("ign_cone_volume",
+        &ConeVolumeDeprecated,
+        "[Deprecated] Compute cone volume")
    .def("ign_cylinder_volume",
         &CylinderVolumeDeprecated,
         "[Deprecated] Compute cylinder volume")

--- a/src/python_pybind11/src/MassMatrix3.hh
+++ b/src/python_pybind11/src/MassMatrix3.hh
@@ -114,6 +114,35 @@ void helpDefineMathMassMatrix3(py::module &m, const std::string &typestr)
        py::arg("_size") = gz::math::Vector3<T>::Zero,
        py::arg("_rot") = gz::math::Quaternion<T>::Identity,
        "Set inertial properties based on a Material and equivalent box.")
+  .def("set_from_cone_z",
+       py::overload_cast<const Material&, const T, const T,
+                         const gz::math::Quaternion<T>&>
+                         (&Class::SetFromConeZ),
+       py::arg("_mat") = gz::math::Material(),
+       py::arg("_length") = 0,
+       py::arg("_radius") = 0,
+       py::arg("_rot") = gz::math::Quaternion<T>::Identity,
+       "Set inertial properties based on a Material and equivalent "
+       "cone aligned with Z axis.")
+  .def("set_from_cone_z",
+       py::overload_cast<const T, const T, const T,
+                         const gz::math::Quaternion<T>&>
+                         (&Class::SetFromConeZ),
+       py::arg("_mass") = 0,
+       py::arg("_length") = 0,
+       py::arg("_radius") = 0,
+       py::arg("_rot") = gz::math::Quaternion<T>::Identity,
+       "Set inertial properties based on a Material and equivalent "
+       "cone aligned with Z axis.")
+  .def("set_from_cone_z",
+       py::overload_cast<const T, const T,
+                         const gz::math::Quaternion<T>&>
+                         (&Class::SetFromConeZ),
+       py::arg("_length") = 0,
+       py::arg("_radius") = 0,
+       py::arg("_rot") = gz::math::Quaternion<T>::Identity,
+       "Set inertial properties based on a Material and equivalent "
+       "cone aligned with Z axis.")
   .def("set_from_cylinder_z",
        py::overload_cast<const Material&, const T, const T,
                          const gz::math::Quaternion<T>&>

--- a/src/python_pybind11/src/_gz_math_pybind11.cc
+++ b/src/python_pybind11/src/_gz_math_pybind11.cc
@@ -19,6 +19,7 @@
 #include "Box.hh"
 #include "Capsule.hh"
 #include "Color.hh"
+#include "Cone.hh"
 #include "Cylinder.hh"
 #include "DiffDriveOdometry.hh"
 #include "Ellipsoid.hh"
@@ -167,6 +168,8 @@ PYBIND11_MODULE(BINDINGS_MODULE_NAME, m)
   gz::math::python::defineMathMassMatrix3(m, "MassMatrix3");
 
   gz::math::python::defineMathSphere<double>(m, "Sphered");
+
+  gz::math::python::defineMathCone<double>(m, "Coned");
 
   gz::math::python::defineMathCylinder<double>(m, "Cylinderd");
 

--- a/src/python_pybind11/test/Cone_TEST.py
+++ b/src/python_pybind11/test/Cone_TEST.py
@@ -1,0 +1,126 @@
+# Copyright 2024 CogniPilot Foundation
+# Copyright 2024 Open Source Robotics Foundation
+# Copyright 2024 Rudis Laboratories
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import unittest
+
+import gz
+from gz.math7 import Coned, MassMatrix3d, Material, Quaterniond
+
+
+class TestCone(unittest.TestCase):
+
+    def test_constructor(self):
+        # Default constructor
+        cone = Coned()
+        self.assertEqual(0.0, cone.length())
+        self.assertEqual(0.0, cone.radius())
+        self.assertEqual(Quaterniond.IDENTITY, cone.rotational_offset())
+        self.assertEqual(Material(), cone.mat())
+
+        cone2 = Coned()
+        self.assertEqual(cone, cone2)
+
+        # Length and radius constructor
+        cone = Coned(1.0, 2.0)
+        self.assertEqual(1.0, cone.length())
+        self.assertEqual(2.0, cone.radius())
+        self.assertEqual(Quaterniond.IDENTITY, cone.rotational_offset())
+        self.assertEqual(Material(), cone.mat())
+
+        cone2 = Coned(1.0, 2.0)
+        self.assertEqual(cone, cone2)
+
+        # Length, radius, and rot constructor
+        cone = Coned(1.0, 2.0, Quaterniond(0.1, 0.2, 0.3))
+        self.assertEqual(1.0, cone.length())
+        self.assertEqual(2.0, cone.radius())
+        self.assertEqual(Quaterniond(0.1, 0.2, 0.3),
+                         cone.rotational_offset())
+        self.assertEqual(Material(), cone.mat())
+
+        cone2 = Coned(1.0, 2.0, Quaterniond(0.1, 0.2, 0.3))
+        self.assertEqual(cone, cone2)
+
+        # Length, radius, mat and rot constructor
+        cone = Coned(1.0, 2.0, Material(gz.math7.MaterialType.WOOD),
+                             Quaterniond(0.1, 0.2, 0.3))
+        self.assertEqual(1.0, cone.length())
+        self.assertEqual(2.0, cone.radius())
+        self.assertEqual(Quaterniond(0.1, 0.2, 0.3), cone.rotational_offset())
+        self.assertEqual(Material(gz.math7.MaterialType.WOOD), cone.mat())
+
+        cone2 = Coned(1.0, 2.0, Material(gz.math7.MaterialType.WOOD),
+                              Quaterniond(0.1, 0.2, 0.3))
+        self.assertEqual(cone, cone2)
+
+    def test_mutators(self):
+        cone = Coned()
+        self.assertEqual(0.0, cone.length())
+        self.assertEqual(0.0, cone.radius())
+        self.assertEqual(Quaterniond.IDENTITY, cone.rotational_offset())
+        self.assertEqual(Material(), cone.mat())
+
+        cone.set_length(100.1)
+        cone.set_radius(.123)
+        cone.set_rotational_offset(Quaterniond(1.2, 2.3, 3.4))
+        cone.set_mat(Material(gz.math7.MaterialType.PINE))
+
+        self.assertEqual(100.1, cone.length())
+        self.assertEqual(.123, cone.radius())
+        self.assertEqual(Quaterniond(1.2, 2.3, 3.4), cone.rotational_offset())
+        self.assertEqual(Material(gz.math7.MaterialType.PINE), cone.mat())
+
+    def test_volume_and_density(self):
+        mass = 1.0
+        cone = Coned(1.0, 0.001)
+        expectedVolume = (math.pi * math.pow(0.001, 2) * 1.0 / 3.0)
+        self.assertEqual(expectedVolume, cone.volume())
+
+        expectedDensity = mass / expectedVolume
+        self.assertEqual(expectedDensity, cone.density_from_mass(mass))
+
+        # Bad density
+        cone2 = Coned()
+        self.assertGreater(0.0, cone2.density_from_mass(mass))
+
+    def test_mass(self):
+        mass = 2.0
+        length = 2.0
+        r = 0.1
+        cone = Coned(length, r)
+        cone.set_density_from_mass(mass)
+
+        massMat = MassMatrix3d()
+        ixxIyy = (3/80.0) * mass * (4*r*r + length*length)
+        izz = (3/10.0) * mass * r * r
+
+        expectedMassMat = MassMatrix3d()
+        expectedMassMat.set_inertia_matrix(ixxIyy, ixxIyy, izz, 0.0, 0.0, 0.0)
+        expectedMassMat.set_mass(mass)
+
+        cone.mass_matrix(massMat)
+        self.assertEqual(expectedMassMat, massMat)
+        self.assertEqual(expectedMassMat.mass(), massMat.mass())
+
+        massMat2 = cone.mass_matrix()
+        self.assertEqual(expectedMassMat, massMat2)
+        self.assertEqual(expectedMassMat.diagonal_moments(), massMat2.diagonal_moments())
+        self.assertEqual(expectedMassMat.mass(), massMat2.mass())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/python_pybind11/test/Helpers_TEST.py
+++ b/src/python_pybind11/test/Helpers_TEST.py
@@ -16,7 +16,7 @@ import math
 import unittest
 
 from gz.math7 import (Helpers, gz_box_volume, gz_box_volume_v, gz_cylinder_volume,
-                           gz_sphere_volume, Vector3d, equal, fixnan,
+                           gz_cone_volume, gz_sphere_volume, Vector3d, equal, fixnan,
                            greater_or_near_equal, is_even, is_odd, is_power_of_two, isnan,
                            is_time_string, less_or_near_equal, max, mean, min,
                            parse_float, parse_int, precision, round_up_multiple,

--- a/src/ruby/Cone.i
+++ b/src/ruby/Cone.i
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 CogniPilot Foundation
+ * Copyright 2024 Open Source Robotics Foundation
+ * Copyright 2024 Rudis Laboratories
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+%module cone
+%{
+#include <gz/math/Cone.hh>
+#include <gz/math/config.hh>
+#include <gz/math/MassMatrix3.hh>
+#include <gz/math/Material.hh>
+#include <gz/math/Quaternion.hh>
+%}
+
+namespace gz
+{
+  namespace math
+  {
+    template<typename Precision>
+    class Cone
+    {
+      %rename("%(undercase)s", %$isfunction, notregexmatch$name="^[A-Z]*$") "";
+
+      public: Cone() = default;
+
+      public: Cone(const Precision _length, const Precision _radius,
+                  const gz::math::Quaternion<Precision> &_rotOffset =
+                  gz::math::Quaternion<Precision>::Identity);
+
+      public: Cone(const Precision _length, const Precision _radius,
+                  const gz::math::Material &_mat,
+                  const gz::math::Quaternion<Precision> &_rotOffset =
+                  gz::math::Quaternion<Precision>::Identity);
+
+      public: ~Cone() = default;
+
+      public: Precision Radius() const;
+
+      public: void SetRadius(const Precision _radius);
+
+      public: Precision Length() const;
+
+      public: void SetLength(const Precision _length);
+
+      public: gz::math::Quaternion<Precision> RotationalOffset() const;
+
+      public: void SetRotationalOffset(
+                  const gz::math::Quaternion<Precision> &_rotOffset);
+
+      public: const gz::math::Material &Mat() const;
+
+      public: void SetMat(const gz::math::Material &_mat);
+
+      public: bool MassMatrix(gz::math::MassMatrix3<double> &_massMat) const;
+
+      public: bool operator==(const Cone &_cone) const;
+
+      public: Precision Volume() const;
+
+      public: Precision DensityFromMass(const Precision _mass) const;
+
+      public: bool SetDensityFromMass(const Precision _mass);
+    };
+    %template(Coned) Cone<double>;
+  }
+}

--- a/src/ruby/Helpers.i
+++ b/src/ruby/Helpers.i
@@ -53,6 +53,9 @@ import math
 def gz_sphere_volume(_radius):
    return (4.0*GZ_PI*math.pow(_radius, 3)/3.0)
 
+def gz_cone_volume(_r, _l):
+  return (_l * GZ_PI * math.pow(_r, 2)/3.0)
+
 def gz_cylinder_volume(_r, _l):
   return (_l * GZ_PI * math.pow(_r, 2))
 

--- a/src/ruby/MassMatrix3.i
+++ b/src/ruby/MassMatrix3.i
@@ -99,10 +99,21 @@ namespace gz
       public: bool SetFromCylinderZ(const T _mass,
                                     const T _length,
                                     const T _radius,
-                            const Quaternion<T> &_rot = Quaternion<T>::Identity);
+                                    const Quaternion<T> &_rot = Quaternion<T>::Identity);
       public: bool SetFromCylinderZ(const T _length,
                                     const T _radius,
                                     const Quaternion<T> &_rot);
+      public: bool SetFromConeZ(const Material &_mat,
+                                const T _length,
+                                const T _radius,
+                                const Quaternion<T> &_rot = Quaternion<T>::Identity);
+      public: bool SetFromConeZ(const T _mass,
+                                const T _length,
+                                const T _radius,
+                                const Quaternion<T> &_rot = Quaternion<T>::Identity);
+      public: bool SetFromConeZ(const T _length,
+                                const T _radius,
+                                const Quaternion<T> &_rot);
       public: bool SetFromSphere(const Material &_mat, const T _radius);
       public: bool SetFromSphere(const T _mass, const T _radius);
       public: bool SetFromSphere(const T _radius);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This helps add the missing cone geometry for primitive/basic parametric shapes:

![conetopple](https://github.com/gazebosim/gz-math/assets/10233412/5fd8f1a1-3a77-4e61-95d5-f053389cd908)
![cone](https://github.com/gazebosim/gz-math/assets/10233412/1c516775-7adb-4318-9c6a-0c09a746a3b0)

And is also valuable for visualizations of emitters/source that typically have conic-based spread as seen in this acoustic attack on an IMU by showing the affected area:

![drone_attack](https://github.com/gazebosim/gz-rendering/assets/10233412/7a6b0dfa-8ad6-42c1-83bc-8385ccc4c81a)

Associated PRs:

- https://github.com/gazebosim/gz-gui/pull/620
- https://github.com/gazebosim/gz-math/pull/593
- https://github.com/gazebosim/gz-msgs/pull/441
- https://github.com/gazebosim/gz-physics/pull/638
- https://github.com/gazebosim/gz-rendering/pull/1001
- https://github.com/gazebosim/gz-sim/pull/2404
- https://github.com/gazebosim/sdformat/pull/1415

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
