### PR TITLE
SphericalCoordinates: Added SPHERICAL_DEG and SPHERICAL_RAD, deprecated SPHERICAL

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -7,6 +7,12 @@ release will remove the deprecated code.
 
 ## Gazebo Math 8.X to 9.X
 
+### Additions
+
+1. **SphericalCoordinates.hh**
+    + `SphericalCoordinates::CoordinateType::SPHERICAL_DEG`
+    + `SphericalCoordinates::CoordinateType::SPHERICAL_RAD`
+
 ### Deprecations
 
 1. **graph/Vertex.hh**
@@ -18,6 +24,11 @@ release will remove the deprecated code.
     + The `Edge::NullEdge` static member is deprecated. Please use
       `Vertex::NullEdge()` instead.
       E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L222-R222
+
+1. **SphericalCoordinates.hh**
+    + `SphericalCoordinates::CoordinateType::SPHERICAL` has been deprecated
+      because it is unclear what angular units are used. Instead, explicitly
+      choose either `SPERICAL_DEG` or `SPHERICAL_RAD`.
 
 ## Gazebo Math 7.X to 8.X
 

--- a/include/gz/math/SphericalCoordinates.hh
+++ b/include/gz/math/SphericalCoordinates.hh
@@ -25,6 +25,13 @@
 #include <gz/math/config.hh>
 #include <gz/utils/ImplPtr.hh>
 
+// MSVC doesn't like deprecating enum values with function macros
+#if _MSC_VER
+#define GZ_SPHERICAL_DEPRECATED [[deprecated]]
+#else
+#define GZ_SPHERICAL_DEPRECATED GZ_DEPRECATED(8)
+#endif
+
 namespace gz::math
 {
   // Inline bracket to help doxygen filtering.
@@ -54,8 +61,15 @@ namespace gz::math
     /// \brief Unique identifiers for coordinate types.
     public: enum CoordinateType
             {
-              /// \brief Latitude, Longitude and Altitude by SurfaceType
-              SPHERICAL = 1,
+              /// \brief Latitude, Longitude and Altitude by SurfaceType [rad].
+              /// \deprecated Use `SPHERICAL_RAD` or `SPHERICAL_DEG` instead.
+              SPHERICAL GZ_SPHERICAL_DEPRECATED = 1,
+
+              /// \brief Latitude, Longitude and Altitude by SurfaceType [rad].
+              SPHERICAL_RAD = 1,
+
+              /// \brief Latitude, Longitude and Altitude by SurfaceType [deg].
+              SPHERICAL_DEG = 6,
 
               /// \brief Earth centered, earth fixed Cartesian
               ECEF = 2,
@@ -262,8 +276,9 @@ namespace gz::math
     /// \brief Update coordinate transformation matrix with reference location
     public: void UpdateTransformationMatrix();
 
-    /// \brief Convert between positions in SPHERICAL/ECEF/LOCAL/GLOBAL frame
-    /// Spherical coordinates use radians, while the other frames use meters.
+    /// \brief Convert between positions in SPHERICAL_*/ECEF/LOCAL/GLOBAL frame.
+    /// Cartesian frames use meters. `SPHERICAL_DEG` frame uses degrees.
+    /// `SPHERICAL_RAD` frame uses radians.
     /// \param[in] _pos Position vector in frame defined by parameter _in
     /// \param[in] _in  CoordinateType for input
     /// \param[in] _out CoordinateType for output
@@ -272,8 +287,9 @@ namespace gz::math
             PositionTransform(const gz::math::Vector3d &_pos,
                 const CoordinateType &_in, const CoordinateType &_out) const;
 
-    /// \brief Convert between velocity in SPHERICAL/ECEF/LOCAL/GLOBAL frame
-    /// Spherical coordinates use radians, while the other frames use meters.
+    /// \brief Convert between velocity in ECEF/LOCAL/GLOBAL frame.
+    /// Velocity should not be expressed in SPHERICAL_* frames (such values will
+    /// be passed through). Cartesian frames use meters.
     /// \param[in] _vel Velocity vector in frame defined by parameter _in
     /// \param[in] _in  CoordinateType for input
     /// \param[in] _out CoordinateType for output

--- a/src/python_pybind11/src/SphericalCoordinates.cc
+++ b/src/python_pybind11/src/SphericalCoordinates.cc
@@ -133,22 +133,26 @@ void defineMathSphericalCoordinates(py::module &m, const std::string &typestr)
          "Update coordinate transformation matrix with reference location")
     .def("position_transform",
          &Class::PositionTransform,
-         "Convert between velocity in SPHERICAL/ECEF/LOCAL/GLOBAL frame "
-         "Spherical coordinates use radians, while the other frames use "
-         "meters.")
+         "Convert between positions in SPHERICAL_*/ECEF/LOCAL/GLOBAL frame. "
+         "Cartesian frames use meters. SPHERICAL_DEG frame uses degrees. "
+         "SPHERICAL_RAD frame uses radians.")
     .def("velocity_transform",
          &Class::VelocityTransform,
-         "Convert between velocity in SPHERICAL/ECEF/LOCAL/GLOBAL frame "
-         "Spherical coordinates use radians, while the other frames use "
-         "meters.");
+         "Convert between velocity in ECEF/LOCAL/GLOBAL frame ."
+         "Velocity should not be expressed in SPHERICAL_* frames (such values "
+         "will be passed through). All Cartesian frames use meters.");
 
+   GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
    py::enum_<Class::CoordinateType>(sphericalCoordinates, "CoordinateType")
+       .value("SPHERICAL_RAD", Class::CoordinateType::SPHERICAL_RAD)
+       .value("SPHERICAL_DEG", Class::CoordinateType::SPHERICAL_DEG)
        .value("SPHERICAL", Class::CoordinateType::SPHERICAL)
        .value("ECEF", Class::CoordinateType::ECEF)
        .value("GLOBAL", Class::CoordinateType::GLOBAL)
        .value("LOCAL", Class::CoordinateType::LOCAL)
        .value("LOCAL2", Class::CoordinateType::LOCAL2)
        .export_values();
+   GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
    py::enum_<Class::SurfaceType>(sphericalCoordinates, "SurfaceType")
        .value("EARTH_WGS84", Class::SurfaceType::EARTH_WGS84)
        .value("MOON_SCS", Class::SurfaceType::MOON_SCS)

--- a/src/ruby/SphericalCoordinates.i
+++ b/src/ruby/SphericalCoordinates.i
@@ -41,8 +41,14 @@ namespace gz
 
       public: enum CoordinateType
               {
-                /// \brief Latitude, Longitude and Altitude by SurfaceType
+                /// \brief Latitude, Longitude and Altitude by SurfaceType [rad]
                 SPHERICAL = 1,
+
+                /// \brief Latitude, Longitude and Altitude by SurfaceType [rad]
+                SPHERICAL_RAD = 1,
+
+                /// \brief Latitude, Longitude and Altitude by SurfaceType [deg]
+                SPHERICAL_DEG = 6,
 
                 /// \brief Earth centered, earth fixed Cartesian
                 ECEF = 2,


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-math/pull/235#discussion_r1442439980

## Summary

This change is made to ~~unify~~ **clarify** the units that are inputs/outputs to the coordinate transforms.

This PR deprecates enum value `SPHERICAL` used downstream at least in https://github.com/gazebosim/gz-sim/blob/40aaddc7eb4ca12a03b64e18ffc101db9f9c24ec/src/Util.cc#L694 .

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.