### PR TITLE
Line*.hh: remove unneeded use of static variable

### DIFF
--- a/include/gz/math/Line2.hh
+++ b/include/gz/math/Line2.hh
@@ -180,7 +180,7 @@ namespace gz
       public: bool Intersect(const Line2<T> &_line,
                              double _epsilon = 1e-6) const
       {
-        static math::Vector2<T> ignore;
+        math::Vector2<T> ignore;
         return this->Intersect(_line, ignore, _epsilon);
       }
 

--- a/include/gz/math/Line3.hh
+++ b/include/gz/math/Line3.hh
@@ -263,7 +263,7 @@ namespace gz
       public: bool Intersect(const Line3<T> &_line,
                              double _epsilon = 1e-6) const
       {
-        static math::Vector3<T> ignore;
+        math::Vector3<T> ignore;
         return this->Intersect(_line, ignore, _epsilon);
       }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #269.

## Summary

From https://github.com/gazebosim/gz-math/issues/269#issuecomment-1749694942:

> There are still some destructor-only fiascos. Hopefully the compiler optimizes it away, but I don't think its guaranteed:

~~~
./include/gz/math/Line2.hh:183:        static math::Vector2<T> ignore;
./include/gz/math/Line3.hh:266:        static math::Vector3<T> ignore;
~~~

> The fix for those last two is easy, in any case. Just remove the static. It's way slower to use "static" anyway. A dummy on the stack should be free. A dummy as a mutable global requires checking an initialization lock every time we call that function.

This removes the `static` keyword from those variables.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
