### PR TITLE
Use ImplPtr, fix rule of 0

### DIFF
--- a/include/gz/math/Capsule.hh
+++ b/include/gz/math/Capsule.hh
@@ -25,9 +25,6 @@ namespace gz
 {
   namespace math
   {
-    // Foward declarations
-    class CapsulePrivate;
-
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_MATH_VERSION_NAMESPACE {
     //

--- a/include/gz/math/Cylinder.hh
+++ b/include/gz/math/Cylinder.hh
@@ -26,9 +26,6 @@ namespace gz
 {
   namespace math
   {
-    // Foward declarations
-    class CylinderPrivate;
-
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_MATH_VERSION_NAMESPACE {
     //

--- a/include/gz/math/MecanumDriveOdometry.hh
+++ b/include/gz/math/MecanumDriveOdometry.hh
@@ -29,7 +29,6 @@ namespace gz
   {
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_MATH_VERSION_NAMESPACE {
-    //
     /// \class MecanumDriveOdometry MecanumDriveOdometry.hh
     /// gz/math/MecanumDriveOdometry.hh
     ///
@@ -129,6 +128,7 @@ namespace gz
       /// \return Right wheel radius in meters.
       public: double RightWheelRadius() const;
 
+      /// \brief Private data pointer.
       GZ_UTILS_IMPL_PTR(dataPtr)
     };
     }  // namespace GZ_MATH_VERSION_NAMESPACE

--- a/include/gz/math/MecanumDriveOdometry.hh
+++ b/include/gz/math/MecanumDriveOdometry.hh
@@ -18,10 +18,10 @@
 #define GZ_MATH_MECANUMDRIVEODOMETRY_HH_
 
 #include <chrono>
-#include <memory>
 #include <gz/math/Angle.hh>
 #include <gz/math/Export.hh>
 #include <gz/math/config.hh>
+#include <gz/utils/ImplPtr.hh>
 
 namespace gz
 {
@@ -29,9 +29,7 @@ namespace gz
   {
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_MATH_VERSION_NAMESPACE {
-    // Forward declarations.
-    class MecanumDriveOdometryPrivate;
-
+    //
     /// \class MecanumDriveOdometry MecanumDriveOdometry.hh
     /// gz/math/MecanumDriveOdometry.hh
     ///
@@ -58,9 +56,6 @@ namespace gz
       /// \param[in] _windowSize Rolling window size used to compute the
       /// velocity mean
       public: explicit MecanumDriveOdometry(size_t _windowSize = 10);
-
-      /// \brief Destructor.
-      public: ~MecanumDriveOdometry();
 
       /// \brief Initialize the odometry
       /// \param[in] _time Current time.
@@ -134,18 +129,7 @@ namespace gz
       /// \return Right wheel radius in meters.
       public: double RightWheelRadius() const;
 
-
-#ifdef _WIN32
-// Disable warning C4251 which is triggered by
-// std::unique_ptr
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
-      /// \brief Private data pointer.
-      private: std::unique_ptr<MecanumDriveOdometryPrivate> dataPtr;
-#ifdef _WIN32
-#pragma warning(pop)
-#endif
+      GZ_UTILS_IMPL_PTR(dataPtr)
     };
     }  // namespace GZ_MATH_VERSION_NAMESPACE
   }  // namespace math

--- a/include/gz/math/SpeedLimiter.hh
+++ b/include/gz/math/SpeedLimiter.hh
@@ -29,7 +29,6 @@ namespace math
 {
 // Inline bracket to help doxygen filtering.
 inline namespace GZ_MATH_VERSION_NAMESPACE {
-  //
   /// \brief Class to limit velocity, acceleration and jerk.
   class GZ_MATH_VISIBLE SpeedLimiter
   {
@@ -125,6 +124,7 @@ inline namespace GZ_MATH_VERSION_NAMESPACE {
         double _prevPrevVel,
         std::chrono::steady_clock::duration _dt) const;
 
+    /// \brief Private data pointer.
     GZ_UTILS_IMPL_PTR(dataPtr)
   };
   }

--- a/include/gz/math/SpeedLimiter.hh
+++ b/include/gz/math/SpeedLimiter.hh
@@ -19,9 +19,9 @@
 #define GZ_MATH_SYSTEMS_SPEEDLIMITER_HH_
 
 #include <chrono>
-#include <memory>
 #include <gz/math/config.hh>
 #include "gz/math/Helpers.hh"
+#include <gz/utils/ImplPtr.hh>
 
 namespace gz
 {
@@ -29,18 +29,13 @@ namespace math
 {
 // Inline bracket to help doxygen filtering.
 inline namespace GZ_MATH_VERSION_NAMESPACE {
-  // Forward declaration.
-  class SpeedLimiterPrivate;
-
+  //
   /// \brief Class to limit velocity, acceleration and jerk.
   class GZ_MATH_VISIBLE SpeedLimiter
   {
     /// \brief Constructor.
     /// There are no limits by default.
     public: SpeedLimiter();
-
-    /// \brief Destructor.
-    public: ~SpeedLimiter();
 
     /// \brief Set minimum velocity limit in m/s, usually <= 0.
     /// \param[in] _lim Minimum velocity.
@@ -130,17 +125,7 @@ inline namespace GZ_MATH_VERSION_NAMESPACE {
         double _prevPrevVel,
         std::chrono::steady_clock::duration _dt) const;
 
-#ifdef _WIN32
-// Disable warning C4251 which is triggered by
-// std::unique_ptr
-#pragma warning(push)
-#pragma warning(disable: 4251)
-#endif
-    /// \brief Private data pointer.
-    private: std::unique_ptr<SpeedLimiterPrivate> dataPtr;
-#ifdef _WIN32
-#pragma warning(pop)
-#endif
+    GZ_UTILS_IMPL_PTR(dataPtr)
   };
   }
 }

--- a/include/gz/math/Sphere.hh
+++ b/include/gz/math/Sphere.hh
@@ -27,9 +27,6 @@ namespace gz
 {
   namespace math
   {
-    // Foward declarations
-    class SpherePrivate;
-
     // Inline bracket to help doxygen filtering.
     inline namespace GZ_MATH_VERSION_NAMESPACE {
     //

--- a/src/MecanumDriveOdometry.cc
+++ b/src/MecanumDriveOdometry.cc
@@ -18,15 +18,18 @@
 #include "gz/math/MecanumDriveOdometry.hh"
 #include "gz/math/RollingMean.hh"
 
-using namespace gz;
-using namespace math;
-
 // The implementation was borrowed from: https://github.com/ros-controls/ros_controllers/blob/melodic-devel/diff_drive_controller/src/odometry.cpp
 // And these calculations are based on the following references:
 // https://robohub.org/drive-kinematics-skid-steer-and-mecanum-ros-twist-included
 // https://research.ijcaonline.org/volume113/number3/pxc3901586.pdf
 
-class gz::math::MecanumDriveOdometryPrivate
+namespace gz
+{
+namespace math
+{
+inline namespace GZ_MATH_VERSION_NAMESPACE
+{
+class MecanumDriveOdometryPrivate
 {
   /// \brief Integrates the pose.
   /// \param[in] _linear Linear velocity.
@@ -51,7 +54,7 @@ class gz::math::MecanumDriveOdometryPrivate
   public: double y{0.0};
 
   /// \brief Current heading in radians.
-  public: Angle heading;
+  public: gz::math::Angle heading;
 
   /// \brief Current linear velocity in meter/second.
   public: double linearVel{0.0};
@@ -60,7 +63,7 @@ class gz::math::MecanumDriveOdometryPrivate
   public: double lateralVel{0.0};
 
   /// \brief Current angular velocity in radians/second.
-  public: Angle angularVel;
+  public: gz::math::Angle angularVel;
 
   /// \brief Left wheel radius in meters.
   public: double leftWheelRadius{0.0};
@@ -87,17 +90,23 @@ class gz::math::MecanumDriveOdometryPrivate
   public: double backRightWheelOldPos{0.0};
 
   /// \brief Rolling mean accumulators for the linear velocity
-  public: RollingMean linearMean;
+  public: gz::math::RollingMean linearMean;
 
   /// \brief Rolling mean accumulators for the lateral velocity
-  public: RollingMean lateralMean;
+  public: gz::math::RollingMean lateralMean;
 
   /// \brief Rolling mean accumulators for the angular velocity
-  public: RollingMean angularMean;
+  public: gz::math::RollingMean angularMean;
 
   /// \brief Initialized flag.
   public: bool initialized{false};
 };
+}
+}
+}
+
+using namespace gz;
+using namespace math;
 
 //////////////////////////////////////////////////
 MecanumDriveOdometry::MecanumDriveOdometry(size_t _windowSize)

--- a/src/MecanumDriveOdometry.cc
+++ b/src/MecanumDriveOdometry.cc
@@ -29,8 +29,17 @@ namespace math
 {
 inline namespace GZ_MATH_VERSION_NAMESPACE
 {
-class MecanumDriveOdometryPrivate
+class MecanumDriveOdometry::Implementation
 {
+  /// \brief Constructor.
+  /// \param[in] _windowSize Rolling window size used to compute the
+  /// velocity mean.
+  public: explicit Implementation(size_t _windowSize)
+    : linearMean(_windowSize), lateralMean(_windowSize),
+      angularMean(_windowSize)
+  {
+  }
+
   /// \brief Integrates the pose.
   /// \param[in] _linear Linear velocity.
   /// \param[in] _lateral Lateral velocity.
@@ -110,15 +119,7 @@ using namespace math;
 
 //////////////////////////////////////////////////
 MecanumDriveOdometry::MecanumDriveOdometry(size_t _windowSize)
-  : dataPtr(new MecanumDriveOdometryPrivate)
-{
-  this->dataPtr->linearMean.SetWindowSize(_windowSize);
-  this->dataPtr->lateralMean.SetWindowSize(_windowSize);
-  this->dataPtr->angularMean.SetWindowSize(_windowSize);
-}
-
-//////////////////////////////////////////////////
-MecanumDriveOdometry::~MecanumDriveOdometry()
+  : dataPtr(gz::utils::MakeImpl<Implementation>(_windowSize))
 {
 }
 
@@ -301,7 +302,7 @@ double MecanumDriveOdometry::RightWheelRadius() const
 }
 
 //////////////////////////////////////////////////
-void MecanumDriveOdometryPrivate::IntegrateRungeKutta2(
+void MecanumDriveOdometry::Implementation::IntegrateRungeKutta2(
     double _linear, double _lateral, double _angular)
 {
   const double direction = *this->heading + _angular * 0.5;
@@ -313,7 +314,7 @@ void MecanumDriveOdometryPrivate::IntegrateRungeKutta2(
 }
 
 //////////////////////////////////////////////////
-void MecanumDriveOdometryPrivate::IntegrateExact(double _linear,
+void MecanumDriveOdometry::Implementation::IntegrateExact(double _linear,
   double _lateral, double _angular)
 {
   if (std::fabs(_angular) < 1e-6)

--- a/src/SpeedLimiter.cc
+++ b/src/SpeedLimiter.cc
@@ -18,11 +18,13 @@
 #include "gz/math/Helpers.hh"
 #include "gz/math/SpeedLimiter.hh"
 
-using namespace gz;
-using namespace math;
-
-/// \brief Private SpeedLimiter data class.
-class gz::math::SpeedLimiterPrivate
+namespace gz
+{
+namespace math
+{
+inline namespace GZ_MATH_VERSION_NAMESPACE
+{
+class SpeedLimiter::Implementation
 {
   /// \brief Minimum velocity limit.
   public: double minVelocity{-std::numeric_limits<double>::infinity()};
@@ -42,15 +44,18 @@ class gz::math::SpeedLimiterPrivate
   /// \brief Maximum jerk limit.
   public: double maxJerk{std::numeric_limits<double>::infinity()};
 };
+}
+}
+}
+
+using namespace gz;
+using namespace math;
 
 //////////////////////////////////////////////////
 SpeedLimiter::SpeedLimiter()
-  : dataPtr(std::make_unique<SpeedLimiterPrivate>())
+  : dataPtr(gz::utils::MakeImpl<Implementation>())
 {
 }
-
-//////////////////////////////////////////////////
-SpeedLimiter::~SpeedLimiter() = default;
 
 //////////////////////////////////////////////////
 void SpeedLimiter::SetMinVelocity(double _lim)


### PR DESCRIPTION
# 🎉 New feature

Use gz/utils/ImplPtr and fix rule of 0 violations

## Summary

This switches from raw data pointers to `gz::utils::ImplPtr` for `SpeedLimiter` and `MecanumOdometry` and deletes the destructor definitions to satisfy the rule of 0 for these classes.

Also remove some unneeded forward `class` declarations.

## Test it

Build and run unit tests.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
