### PR TITLE
Revert "Fix potential unsafe initialization in the Graph class (#606)"

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,20 +5,6 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
-## Gazebo Math 8.X to 9.X
-
-### Deprecations
-
-1. **graph/Vertex.hh**
-    + The `Vertex::NullVertex` static member is deprecated. Please use
-      `Vertex::NullVertex()` instead.
-      E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L153-R153
-
-1. **graph/Edge.hh**
-    + The `Edge::NullEdge` static member is deprecated. Please use
-      `Vertex::NullEdge()` instead.
-      E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L222-R222
-
 ## Gazebo Math 7.X to 8.X
 
 ### Breaking Changes

--- a/include/gz/math/graph/Edge.hh
+++ b/include/gz/math/graph/Edge.hh
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <functional>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <set>
 
@@ -206,8 +205,7 @@ namespace graph
   class UndirectedEdge : public Edge<E>
   {
     /// \brief An invalid undirected edge.
-    // Deprecated in favor of NullEdge().
-    public: static UndirectedEdge<E> GZ_DEPRECATED(8) NullEdge;
+    public: static UndirectedEdge<E> NullEdge;
 
     /// \brief Constructor.
     /// \param[in] _vertices The vertices of the edge.
@@ -259,7 +257,6 @@ namespace graph
   };
 
   /// \brief An invalid undirected edge.
-  // Deprecated in favor of NullEdge().
   template<typename E>
   UndirectedEdge<E> UndirectedEdge<E>::NullEdge(
     VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
@@ -271,8 +268,7 @@ namespace graph
   class DirectedEdge : public Edge<E>
   {
     /// \brief An invalid directed edge.
-    // Deprecated in favor of NullEdge().
-    public: static DirectedEdge<E> GZ_DEPRECATED(8) NullEdge;
+    public: static DirectedEdge<E> NullEdge;
 
     /// \brief Constructor.
     /// \param[in] _vertices The vertices of the edge.
@@ -336,19 +332,9 @@ namespace graph
   };
 
   /// \brief An invalid directed edge.
-  // Deprecated in favor of NullEdge().
   template<typename E>
   DirectedEdge<E> DirectedEdge<E>::NullEdge(
     VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
-
-  /// \brief An invalid edge.
-  template<typename E, typename EdgeType>
-  EdgeType &NullEdge()
-  {
-    static auto e = std::make_unique<EdgeType>(
-      VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
-    return *e;
-  }
 }
 }
 }

--- a/include/gz/math/graph/Graph.hh
+++ b/include/gz/math/graph/Graph.hh
@@ -150,7 +150,7 @@ namespace graph
         {
           std::cerr << "[Graph::AddVertex()] The limit of vertices has been "
                     << "reached. Ignoring vertex." << std::endl;
-          return NullVertex<V>();
+          return Vertex<V>::NullVertex;
         }
       }
 
@@ -163,7 +163,7 @@ namespace graph
       {
         std::cerr << "[Graph::AddVertex()] Repeated vertex [" << id << "]"
                   << std::endl;
-        return NullVertex<V>();
+        return Vertex<V>::NullVertex;
       }
 
       // Link the vertex with an empty list of edges.
@@ -219,7 +219,7 @@ namespace graph
       {
         std::cerr << "[Graph::AddEdge()] The limit of edges has been reached. "
                   << "Ignoring edge." << std::endl;
-        return NullEdge<E, EdgeType>();
+        return EdgeType::NullEdge;
       }
 
       EdgeType newEdge(_vertices, _data, _weight, id);
@@ -240,7 +240,7 @@ namespace graph
       for (auto const &v : {edgeVertices.first, edgeVertices.second})
       {
         if (this->vertices.find(v) == this->vertices.end())
-          return NullEdge<E, EdgeType>();
+          return EdgeType::NullEdge;
       }
 
       // Link the new edge.
@@ -611,7 +611,7 @@ namespace graph
     {
       auto iter = this->vertices.find(_id);
       if (iter == this->vertices.end())
-        return NullVertex<V>();
+        return Vertex<V>::NullVertex;
 
       return iter->second;
     }
@@ -624,7 +624,7 @@ namespace graph
     {
       auto iter = this->vertices.find(_id);
       if (iter == this->vertices.end())
-        return NullVertex<V>();
+        return Vertex<V>::NullVertex;
 
       return iter->second;
     }
@@ -646,7 +646,7 @@ namespace graph
 
       // Quit early if there is no adjacency entry
       if (adjIt == this->adjList.end())
-        return NullEdge<E, EdgeType>();
+        return EdgeType::NullEdge;
 
       // Loop over the edges in the source vertex's adjacency list
       for (std::set<EdgeId>::const_iterator edgIt = adjIt->second.begin();
@@ -665,7 +665,7 @@ namespace graph
         }
       }
 
-      return NullEdge<E, EdgeType>();
+      return EdgeType::NullEdge;
     }
 
     /// \brief Get a reference to an edge using its Id.
@@ -676,7 +676,7 @@ namespace graph
     {
       auto iter = this->edges.find(_id);
       if (iter == this->edges.end())
-        return NullEdge<E, EdgeType>();
+        return EdgeType::NullEdge;
 
       return iter->second;
     }
@@ -689,7 +689,7 @@ namespace graph
     {
       auto iter = this->edges.find(_id);
       if (iter == this->edges.end())
-        return NullEdge<E, EdgeType>();
+        return EdgeType::NullEdge;
 
       return iter->second;
     }

--- a/include/gz/math/graph/Vertex.hh
+++ b/include/gz/math/graph/Vertex.hh
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <functional>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -46,7 +45,7 @@ namespace graph
   using VertexId_P = std::pair<VertexId, VertexId>;
 
   /// \brief Represents an invalid Id.
-  constexpr VertexId kNullId = MAX_UI64;
+  static const VertexId kNullId = MAX_UI64;
 
   /// \brief A vertex of a graph. It stores user information, an optional name,
   /// and keeps an internal unique Id. This class does not enforce to choose a
@@ -55,8 +54,7 @@ namespace graph
   class Vertex
   {
     /// \brief An invalid vertex.
-    // Deprecated in favor of NullVertex().
-    public: static Vertex<V> GZ_DEPRECATED(8) NullVertex;
+    public: static Vertex<V> NullVertex;
 
     /// \brief Constructor.
     /// \param[in] _name Non-unique vertex name.
@@ -138,17 +136,8 @@ namespace graph
   };
 
   /// \brief An invalid vertex.
-  // Deprecated in favor of NullVertex().
   template<typename V>
   Vertex<V> Vertex<V>::NullVertex("__null__", V(), kNullId);
-
-  /// \brief An invalid vertex.
-  template<typename V>
-  Vertex<V> &NullVertex()
-  {
-    static auto v = std::make_unique<Vertex<V>>("__null__", V(), kNullId);
-    return *v;
-  }
 
   /// \def VertexRef_M
   /// \brief Map of vertices. The key is the vertex Id. The value is a


### PR DESCRIPTION
# 🦟 Bug fix

This reverts commit 17585a92918b16340d57b5746e0a50d8e114b2d4.

## Summary

It appears that #606 and https://github.com/gazebosim/sdformat/pull/1458 caused test failures in gz-sim (see https://github.com/osrf/buildfarm-tools/issues/67#issuecomment-2232120738). I opened a test PR in gz-sim (https://github.com/gazebosim/gz-sim/pull/2482) that builds against gz-math8 and sdformat15 with those changes reverted, and the tests were fixed:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-pr_any-homebrew-amd64&build=637)](https://build.osrfoundation.org/job/gz_sim-ci-pr_any-homebrew-amd64/637/) https://build.osrfoundation.org/job/gz_sim-ci-pr_any-homebrew-amd64/637/

I don't know why this broke tests, but I propose reverting these changes for now until we can figure it out.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**.
