### PR TITLE
Fix flaky Stopwatch test

### DIFF
--- a/src/Stopwatch_TEST.cc
+++ b/src/Stopwatch_TEST.cc
@@ -155,6 +155,9 @@ TEST(Stopwatch, StartStopReset)
   watch.Start(true);
   EXPECT_TRUE(watch.Running());
   EXPECT_LT(watch.StopTime(), watch.StartTime());
+  // Add a small sleep to make sure that there's is some time elapsed between
+  // calling Start(true) above and ElapsedRunTime() below.
+  std::this_thread::sleep_for(std::chrono::microseconds(1));
   EXPECT_NE(steady_clock::duration::zero(), watch.ElapsedRunTime());
   EXPECT_EQ(steady_clock::duration::zero(), watch.ElapsedStopTime());
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Adds a small sleep between starting the timer and querying the elapsed time to avoid flakiness.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
