### PR TITLE
Retry fix for unsafe initialization in graph classes

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,20 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Math 8.X to 9.X
+
+### Deprecations
+
+1. **graph/Vertex.hh**
+    + The `Vertex::NullVertex` static member is deprecated. Please use
+      `Vertex::NullVertex()` instead.
+      E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L153-R153
+
+1. **graph/Edge.hh**
+    + The `Edge::NullEdge` static member is deprecated. Please use
+      `Vertex::NullEdge()` instead.
+      E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L222-R222
+
 ## Gazebo Math 7.X to 8.X
 
 ### Breaking Changes

--- a/include/gz/math/graph/Edge.hh
+++ b/include/gz/math/graph/Edge.hh
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <set>
 
@@ -203,7 +204,8 @@ namespace graph
   class UndirectedEdge : public Edge<E>
   {
     /// \brief An invalid undirected edge.
-    public: static UndirectedEdge<E> NullEdge;
+    // Deprecated in favor of NullEdge().
+    public: static UndirectedEdge<E> GZ_DEPRECATED(8) NullEdge;
 
     /// \brief Constructor.
     /// \param[in] _vertices The vertices of the edge.
@@ -255,6 +257,7 @@ namespace graph
   };
 
   /// \brief An invalid undirected edge.
+  // Deprecated in favor of NullEdge().
   template<typename E>
   UndirectedEdge<E> UndirectedEdge<E>::NullEdge(
     VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
@@ -266,7 +269,8 @@ namespace graph
   class DirectedEdge : public Edge<E>
   {
     /// \brief An invalid directed edge.
-    public: static DirectedEdge<E> NullEdge;
+    // Deprecated in favor of NullEdge().
+    public: static DirectedEdge<E> GZ_DEPRECATED(8) NullEdge;
 
     /// \brief Constructor.
     /// \param[in] _vertices The vertices of the edge.
@@ -330,9 +334,19 @@ namespace graph
   };
 
   /// \brief An invalid directed edge.
+  // Deprecated in favor of NullEdge().
   template<typename E>
   DirectedEdge<E> DirectedEdge<E>::NullEdge(
     VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
+
+  /// \brief An invalid edge.
+  template<typename E, typename EdgeType>
+  EdgeType &NullEdge()
+  {
+    static auto e = std::make_unique<EdgeType>(
+      VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
+    return *e;
+  }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE
 }  // namespace gz::math

--- a/include/gz/math/graph/Edge.hh
+++ b/include/gz/math/graph/Edge.hh
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <functional>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <set>
 
@@ -343,9 +342,9 @@ namespace graph
   template<typename E, typename EdgeType>
   EdgeType &NullEdge()
   {
-    static auto e = std::make_unique<EdgeType>(
+    static EdgeType e(
       VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
-    return *e;
+    return e;
   }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE

--- a/include/gz/math/graph/Edge.hh
+++ b/include/gz/math/graph/Edge.hh
@@ -25,7 +25,8 @@
 #include <set>
 
 #include <gz/math/config.hh>
-#include "gz/math/graph/Vertex.hh"
+#include <gz/math/graph/Vertex.hh>
+#include <gz/utils/NeverDestroyed.hh>
 
 namespace gz::math
 {
@@ -342,9 +343,9 @@ namespace graph
   template<typename E, typename EdgeType>
   EdgeType &NullEdge()
   {
-    static EdgeType e(
+    static gz::utils::NeverDestroyed<EdgeType> e(
       VertexId_P(kNullId, kNullId), E(), 1.0, kNullId);
-    return e;
+    return e.Access();
   }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE

--- a/include/gz/math/graph/Graph.hh
+++ b/include/gz/math/graph/Graph.hh
@@ -148,7 +148,7 @@ namespace graph
         {
           std::cerr << "[Graph::AddVertex()] The limit of vertices has been "
                     << "reached. Ignoring vertex." << std::endl;
-          return Vertex<V>::NullVertex;
+          return NullVertex<V>();
         }
       }
 
@@ -161,7 +161,7 @@ namespace graph
       {
         std::cerr << "[Graph::AddVertex()] Repeated vertex [" << id << "]"
                   << std::endl;
-        return Vertex<V>::NullVertex;
+        return NullVertex<V>();
       }
 
       // Link the vertex with an empty list of edges.
@@ -217,7 +217,7 @@ namespace graph
       {
         std::cerr << "[Graph::AddEdge()] The limit of edges has been reached. "
                   << "Ignoring edge." << std::endl;
-        return EdgeType::NullEdge;
+        return NullEdge<E, EdgeType>();
       }
 
       EdgeType newEdge(_vertices, _data, _weight, id);
@@ -238,7 +238,7 @@ namespace graph
       for (auto const &v : {edgeVertices.first, edgeVertices.second})
       {
         if (this->vertices.find(v) == this->vertices.end())
-          return EdgeType::NullEdge;
+          return NullEdge<E, EdgeType>();
       }
 
       // Link the new edge.
@@ -609,7 +609,7 @@ namespace graph
     {
       auto iter = this->vertices.find(_id);
       if (iter == this->vertices.end())
-        return Vertex<V>::NullVertex;
+        return NullVertex<V>();
 
       return iter->second;
     }
@@ -622,7 +622,7 @@ namespace graph
     {
       auto iter = this->vertices.find(_id);
       if (iter == this->vertices.end())
-        return Vertex<V>::NullVertex;
+        return NullVertex<V>();
 
       return iter->second;
     }
@@ -644,7 +644,7 @@ namespace graph
 
       // Quit early if there is no adjacency entry
       if (adjIt == this->adjList.end())
-        return EdgeType::NullEdge;
+        return NullEdge<E, EdgeType>();
 
       // Loop over the edges in the source vertex's adjacency list
       for (std::set<EdgeId>::const_iterator edgIt = adjIt->second.begin();
@@ -663,7 +663,7 @@ namespace graph
         }
       }
 
-      return EdgeType::NullEdge;
+      return NullEdge<E, EdgeType>();
     }
 
     /// \brief Get a reference to an edge using its Id.
@@ -674,7 +674,7 @@ namespace graph
     {
       auto iter = this->edges.find(_id);
       if (iter == this->edges.end())
-        return EdgeType::NullEdge;
+        return NullEdge<E, EdgeType>();
 
       return iter->second;
     }
@@ -687,7 +687,7 @@ namespace graph
     {
       auto iter = this->edges.find(_id);
       if (iter == this->edges.end())
-        return EdgeType::NullEdge;
+        return NullEdge<E, EdgeType>();
 
       return iter->second;
     }

--- a/include/gz/math/graph/Vertex.hh
+++ b/include/gz/math/graph/Vertex.hh
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -43,7 +44,7 @@ namespace graph
   using VertexId_P = std::pair<VertexId, VertexId>;
 
   /// \brief Represents an invalid Id.
-  static const VertexId kNullId = MAX_UI64;
+  constexpr VertexId kNullId = MAX_UI64;
 
   /// \brief A vertex of a graph. It stores user information, an optional name,
   /// and keeps an internal unique Id. This class does not enforce to choose a
@@ -52,7 +53,8 @@ namespace graph
   class Vertex
   {
     /// \brief An invalid vertex.
-    public: static Vertex<V> NullVertex;
+    // Deprecated in favor of NullVertex().
+    public: static Vertex<V> GZ_DEPRECATED(8) NullVertex;
 
     /// \brief Constructor.
     /// \param[in] _name Non-unique vertex name.
@@ -134,8 +136,17 @@ namespace graph
   };
 
   /// \brief An invalid vertex.
+  // Deprecated in favor of NullVertex().
   template<typename V>
   Vertex<V> Vertex<V>::NullVertex("__null__", V(), kNullId);
+
+  /// \brief An invalid vertex.
+  template<typename V>
+  Vertex<V> &NullVertex()
+  {
+    static auto v = std::make_unique<Vertex<V>>("__null__", V(), kNullId);
+    return *v;
+  }
 
   /// \def VertexRef_M
   /// \brief Map of vertices. The key is the vertex Id. The value is a

--- a/include/gz/math/graph/Vertex.hh
+++ b/include/gz/math/graph/Vertex.hh
@@ -27,6 +27,7 @@
 
 #include <gz/math/config.hh>
 #include <gz/math/Helpers.hh>
+#include <gz/utils/NeverDestroyed.hh>
 
 namespace gz::math
 {
@@ -143,8 +144,8 @@ namespace graph
   template<typename V>
   Vertex<V> &NullVertex()
   {
-    static Vertex<V> v("__null__", V(), kNullId);
-    return v;
+    static gz::utils::NeverDestroyed<Vertex<V>> v("__null__", V(), kNullId);
+    return v.Access();
   }
 
   /// \def VertexRef_M

--- a/include/gz/math/graph/Vertex.hh
+++ b/include/gz/math/graph/Vertex.hh
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <functional>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -144,8 +143,8 @@ namespace graph
   template<typename V>
   Vertex<V> &NullVertex()
   {
-    static auto v = std::make_unique<Vertex<V>>("__null__", V(), kNullId);
-    return *v;
+    static Vertex<V> v("__null__", V(), kNullId);
+    return v;
   }
 
   /// \def VertexRef_M


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #269.

## Summary

The is a second attempt at fixing the potentially unsafe initialization issues in the `graph::Edge` and `graph::Vertex` classes after the first attempt in #606 was reverted in #609 due to test failures that it caused in gz-sim (documented in https://github.com/osrf/buildfarm-tools/issues/67#issuecomment-2232120738). This pull request uses a static local variable instead of dynamic memory allocation and doesn't cause gz-sim test failures in my testing.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
