### PR TITLE
Remove clamping of color values

### DIFF
--- a/include/gz/math/Color.hh
+++ b/include/gz/math/Color.hh
@@ -104,7 +104,6 @@ namespace gz::math
                             const float _a = 1.0)
     : r(_r), g(_g), b(_b), a(_a)
     {
-      this->Clamp();
     }
 
     /// \brief Copy Constructor
@@ -267,20 +266,6 @@ namespace gz::math
     /// \param[in] _pt The color to check for inequality
     /// \return True if the this color does not equal _pt
     public: bool operator!=(const Color &_pt) const;
-
-    /// \brief Clamp the color values to valid ranges
-    private: constexpr void Clamp()
-    {
-      // These comparisons are carefully written to handle NaNs correctly.
-      if (!(this->r >= 0)) { this->r = 0; }
-      if (!(this->g >= 0)) { this->g = 0; }
-      if (!(this->b >= 0)) { this->b = 0; }
-      if (!(this->a >= 0)) { this->a = 0; }
-      if (this->r > 1) { this->r = this->r/255.0f; }
-      if (this->g > 1) { this->g = this->g/255.0f; }
-      if (this->b > 1) { this->b = this->b/255.0f; }
-      if (this->a > 1) { this->a = 1; }
-    }
 
     /// \brief Stream insertion operator
     /// \param[in] _out the output stream

--- a/src/Color.cc
+++ b/src/Color.cc
@@ -60,8 +60,6 @@ void Color::Set(const float _r, const float _g, const float _b, const float _a)
   this->g = _g;
   this->b = _b;
   this->a = _a;
-
-  this->Clamp();
 }
 
 //////////////////////////////////////////////////
@@ -124,8 +122,6 @@ void Color::SetFromHSV(const float _h, const float _s, const float _v)
       this->b = q;
       break;
   }
-
-  this->Clamp();
 }
 
 //////////////////////////////////////////////////
@@ -183,7 +179,6 @@ void Color::SetFromYUV(const float _y, const float _u, const float _v)
   this->r = _y + 1.140f*_v;
   this->g = _y - 0.395f*_u - 0.581f*_v;
   this->b = _y + 2.032f*_u;
-  this->Clamp();
 }
 
 //////////////////////////////////////////////////
@@ -385,8 +380,6 @@ const Color &Color::operator+=(const Color &_pt)
   this->b += _pt.b;
   this->a += _pt.a;
 
-  this->Clamp();
-
   return *this;
 }
 
@@ -410,8 +403,6 @@ const Color &Color::operator-=(const Color &_pt)
   this->g -= _pt.g;
   this->b -= _pt.b;
   this->a -= _pt.a;
-
-  this->Clamp();
 
   return *this;
 }
@@ -437,8 +428,6 @@ const Color &Color::operator/=(const Color &_pt)
   this->b /= _pt.b;
   this->a /= _pt.a;
 
-  this->Clamp();
-
   return *this;
 }
 
@@ -462,8 +451,6 @@ const Color &Color::operator*=(const Color &_pt)
   this->g *= _pt.g;
   this->b *= _pt.b;
   this->a *= _pt.a;
-
-  this->Clamp();
 
   return *this;
 }


### PR DESCRIPTION
# 🦟 Bug fix

Toward #200 

## Summary
This removes the clamping of color values, but it doesn't yet enforce the invariant for channels being within [0, 1]. The best way to do that would be to throw an exception, but we don't do that anywhere in the gz-math codebase.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸