### PR TITLE
Check for 0 stddev when generating a random number using normal distribution

### DIFF
--- a/src/Rand.cc
+++ b/src/Rand.cc
@@ -25,6 +25,8 @@
   #include <unistd.h>
 #endif
 
+#include <limits>
+
 #include "gz/math/Rand.hh"
 
 using namespace gz;
@@ -54,7 +56,8 @@ double Rand::DblUniform(double _min, double _max)
 //////////////////////////////////////////////////
 double Rand::DblNormal(double _mean, double _sigma)
 {
-  if (equal(_sigma, 0.0))
+  if (equal(_sigma, 0.0, std::numeric_limits<double>::epsilon()))
+
     return _mean;
 
   NormalRealDist d(_mean, _sigma);

--- a/src/Rand.cc
+++ b/src/Rand.cc
@@ -54,6 +54,9 @@ double Rand::DblUniform(double _min, double _max)
 //////////////////////////////////////////////////
 double Rand::DblNormal(double _mean, double _sigma)
 {
+  if (equal(_sigma, 0.0))
+    return _mean;
+
   NormalRealDist d(_mean, _sigma);
   return d(RandGenerator());
 }
@@ -69,6 +72,9 @@ int32_t Rand::IntUniform(int _min, int _max)
 //////////////////////////////////////////////////
 int32_t Rand::IntNormal(int _mean, int _sigma)
 {
+  if (_sigma == 0)
+    return _mean;
+
   NormalRealDist d(_mean, _sigma);
 
   return static_cast<int32_t>(d(RandGenerator()));

--- a/src/Rand_TEST.cc
+++ b/src/Rand_TEST.cc
@@ -51,6 +51,13 @@ TEST(RandTest, Rand)
     EXPECT_EQ(i, 9);
     EXPECT_NEAR(d, 3.00618, 1e-5);
 #endif
+
+    // Test with sigma == 0
+    d = math::Rand::DblNormal(2, 0);
+    i = math::Rand::IntNormal(10, 0);
+
+    EXPECT_NEAR(d, 2.0, 1e-6);
+    EXPECT_EQ(i, 10);
   }
 #endif
 }

--- a/src/Rand_TEST.cc
+++ b/src/Rand_TEST.cc
@@ -53,11 +53,11 @@ TEST(RandTest, Rand)
 #endif
 
     // Test with sigma == 0
-    d = math::Rand::DblNormal(2, 0);
+    d = math::Rand::DblNormal(2.0, 0.0);
     i = math::Rand::IntNormal(10, 0);
 
-    EXPECT_NEAR(d, 2.0, 1e-6);
-    EXPECT_EQ(i, 10);
+    EXPECT_NEAR(2.0, d, 1e-6);
+    EXPECT_EQ(10, i);
   }
 #endif
 }


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2519

## Summary

We use [std::normal_distribution](https://en.cppreference.com/w/cpp/numeric/random/normal_distribution/normal_distribution) in our Rand class. From the doc:

```
The behavior is undefined if stddev is not greater than zero.
```

So added a check for 0 stddev (sigma) and return mean if its 0.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
