### PR TITLE
Update migration guide

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -39,8 +39,36 @@ release will remove the deprecated code.
       E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L222-R222
 
 1. **SphericalCoordinates.hh**
+    + Deprecated: `gz::math::Vector3d SphericalFromLocalPosition(
+        const gz::math::Vector3d &_xyz) const`
+    + Replacement: `std::optional<math::CoordinateVector3> SphericalFromLocalPosition(
+        const gz::math::CoordinateVector3 &) const`
+    + Deprecated: `gz::math::Vector3d GlobalFromLocalVelocity(
+        const gz::math::Vector3d &_xyz) const`
+    + Replacement: `std::optional<math::CoordinateVector3> GlobalFromLocalVelocity(
+        const gz::math::CoordinateVector3 &) const`
+    + Deprecated: `gz::math::Vector3d LocalFromSphericalPosition(
+        const gz::math::Vector3d &) const`
+    + Replacement: `std::optional<math::CoordinateVector3> LocalFromSphericalPosition(
+        const gz::math::CoordinateVector3 &) const`
+    + Deprecated: `gz::math::Vector3d LocalFromGlobalVelocity(
+        const gz::math::Vector3d &_xyz) const`
+    + Replacement: `std::optional<math::CoordinateVector3> LocalFromGlobalVelocity(
+        const gz::math::CoordinateVector3 &_xyz) const`
+    + Deprecated: `gz::math::Vector3d PositionTransform(const gz::math::Vector3d &,
+        const CoordinateType &, const CoordinateType &) const`
+    + Replacement: `std::optional<gz::math::CoordinateVector3>
+        PositionTransform(const gz::math::CoordinateVector3 &,
+        const CoordinateType &, const CoordinateType &) const`
+    + Deprecated: `gz::math::Vector3d VelocityTransform(
+        const gz::math::Vector3d &,
+        const CoordinateType &, const CoordinateType &) const`
+    + Replacement: `std::optional<gz::math::CoordinateVector3> VelocityTransform(
+        const gz::math::CoordinateVector3 &,
+        const CoordinateType &, const CoordinateType &) const`
     + `math::SphericalCoordinates::LOCAL2` enum is deprecated. Please use
-      `math::SphericalCoordinates::LOCAL` instead
+      `math::SphericalCoordinates::LOCAL` with conversion functions that take a
+      `math::CoordinateVector3` instead.
 
 ## Gazebo Math 6.X to 7.X
 

--- a/Migration.md
+++ b/Migration.md
@@ -5,9 +5,28 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
-## Gazebo Math 8.X to 9.X
+## Gazebo Math 7.X to 8.X
+
+### Breaking Changes
+
+1. All references to `ignition` have been removed. This includes the `ignition/`
+   header files, the `ignition::` namespaces, and `IGN_*` and `IGNITION_*`
+   macros.
+
+1. Behavior change in `math::Color` clamping functionality. Previously when
+   any of the color r, g, or b values are larger than 1, they are assumed to
+   be in the range of [0, 255] and the values are divided by 255
+   by the `math::Color::Clamp` funcion. This is no longer the case. Users are
+   expected to specify floating point r, g, b values in the range of [0, 1].
+   Any values larger than 1 will be clamped to 1.
+
+1. Deprecated functionality from version 7 has been removed.
 
 ### Deprecations
+
+1. **Stopwatch.hh**
+    + The `math::clock` type alias is deprecated. Please use the underlying type
+      (`std::chrono::steady_clock`) directly.
 
 1. **graph/Vertex.hh**
     + The `Vertex::NullVertex` static member is deprecated. Please use
@@ -19,21 +38,9 @@ release will remove the deprecated code.
       `Vertex::NullEdge()` instead.
       E.g.: https://github.com/gazebosim/gz-math/pull/606/files#diff-0c0220a7e72be70337975433eeddc3f5e072ade5cd80dfb1ac03da233c39c983L222-R222
 
-## Gazebo Math 7.X to 8.X
-
-### Breaking Changes
-
-1. All references to `ignition` have been removed. This includes the `ignition/`
-   header files, the `ignition::` namespaces, and `IGN_*` and `IGNITION_*`
-   macros.
-
-1. Deprecated functionality from version 7 has been removed.
-
-### Deprecations
-
-1. **Stopwatch.hh**
-    + The `math::clock` type alias is deprecated. Please use the underlying type
-      (`std::chrono::steady_clock`) directly.
+1. **SphericalCoordinates.hh**
+    + `math::SphericalCoordinates::LOCAL2` enum is deprecated. Please use
+      `math::SphericalCoordinates::LOCAL` instead
 
 ## Gazebo Math 6.X to 7.X
 

--- a/Migration.md
+++ b/Migration.md
@@ -20,6 +20,11 @@ release will remove the deprecated code.
    expected to specify floating point r, g, b values in the range of [0, 1].
    Any values larger than 1 will be clamped to 1.
 
+1. `math::SphericalCoordinates::LOCAL` now gives ENU coordinates instead of WNU.
+Both `math::SphericalCoordinates::LOCAL2` and
+`math::SphericalCoordinates::LOCAL` have the same behaviour now with
+`math::SphericalCoordinates::LOCAL2` being deprecated.
+
 1. Deprecated functionality from version 7 has been removed.
 
 ### Deprecations


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

* Moved graph deprecation entries to math 8x. (https://github.com/gazebosim/gz-math/pull/612)
* Added entry about change in `math::Color` clamping behavior (https://github.com/gazebosim/gz-math/pull/613)
* Added entry about `math::SphericalCoordinates::LOCAL2` enum deprecation (https://github.com/gazebosim/gz-math/pull/616)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

