### PR TITLE
Fix tolerance for axis-angle conversion of quaternions

### DIFF
--- a/include/gz/math/Quaternion.hh
+++ b/include/gz/math/Quaternion.hh
@@ -543,8 +543,8 @@ namespace gz::math
     /// \param[out] _angle CCW angle in radians.
     public: void AxisAngle(Vector3<T> &_axis, T &_angle) const
     {
-      T len = sqrt(this->qx*this->qx + this->qy*this->qy + this->qz*this->qz);
-      if (equal<T>(len, static_cast<T>(0)))
+      T sqLen = this->qx*this->qx + this->qy*this->qy + this->qz*this->qz;
+      if (equal<T>(sqLen, static_cast<T>(0), 1e-12))
       {
         _angle = 0.0;
         _axis.Set(1, 0, 0);
@@ -552,7 +552,7 @@ namespace gz::math
       else
       {
         _angle = 2.0 * acos(this->qw);
-        T invLen =  1.0 / len;
+        T invLen =  1.0 / sqrt(sqLen);
         _axis.Set(this->qx*invLen, this->qy*invLen, this->qz*invLen);
       }
     }

--- a/include/gz/math/Quaternion.hh
+++ b/include/gz/math/Quaternion.hh
@@ -544,7 +544,7 @@ namespace gz::math
     public: void AxisAngle(Vector3<T> &_axis, T &_angle) const
     {
       T sqLen = this->qx*this->qx + this->qy*this->qy + this->qz*this->qz;
-      if (equal<T>(sqLen, static_cast<T>(0), 1e-12))
+      if (equal<T>(sqLen, static_cast<T>(0), static_cast<T>(1e-12)))
       {
         _angle = 0.0;
         _axis.Set(1, 0, 0);

--- a/include/gz/math/Quaternion.hh
+++ b/include/gz/math/Quaternion.hh
@@ -543,7 +543,7 @@ namespace gz::math
     /// \param[out] _angle CCW angle in radians.
     public: void AxisAngle(Vector3<T> &_axis, T &_angle) const
     {
-      T len = this->qx*this->qx + this->qy*this->qy + this->qz*this->qz;
+      T len = sqrt(this->qx*this->qx + this->qy*this->qy + this->qz*this->qz);
       if (equal<T>(len, static_cast<T>(0)))
       {
         _angle = 0.0;
@@ -552,7 +552,7 @@ namespace gz::math
       else
       {
         _angle = 2.0 * acos(this->qw);
-        T invLen =  1.0 / sqrt(len);
+        T invLen =  1.0 / len;
         _axis.Set(this->qx*invLen, this->qy*invLen, this->qz*invLen);
       }
     }

--- a/src/Quaternion_TEST.cc
+++ b/src/Quaternion_TEST.cc
@@ -453,6 +453,17 @@ TEST(QuaternionTest, Math)
   q.AxisAngle(axis, angle);
   EXPECT_TRUE(axis == math::Vector3d(1, 0, 0));
   EXPECT_TRUE(math::equal(angle, 0.0, 1e-3));
+
+  {
+    // Verify that small quaternions can be converted to small axis angle.
+    // Quaternions of length 1e-6 (default epsilon value in math::equal) or
+    // larger should be treated as non-zero for conversion to axis angle.
+    q.SetFromAxisAngle(0, 0, 1, 1e-4);
+    q.AxisAngle(axis, angle);
+    EXPECT_TRUE(axis == math::Vector3d(0, 0, 1));
+    EXPECT_TRUE(math::equal(angle, 1e-4));
+  }
+
   {
     // simple 180 rotation about yaw, should result in x and y flipping signs
     q = math::Quaterniond(0, 0, GZ_PI);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Quaternions smaller than 1e-3 in length are currently treated as 0 when converting to axis angle. This is because the squared length of the quaternion is compared to 0 with an epsilon of 1e-6. The fix is to compare the length of the quaternion instead of the squared length so that only a quaternion of length smaller than 1e-6 (default epsilon in `math::equal(...)`) is treated as zero for this conversion.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
