### PR TITLE
Merge gz-math7 ➡️  gz-math8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -68,6 +68,20 @@
 
 ## Gazebo Math 7.x
 
+### Gazebo Math 7.5.1 (2024-08-23)
+
+1. Fix tolerance for axis-angle conversion of quaternions
+    * [Pull request #620](https://github.com/gazebosim/gz-math/pull/620)
+
+1. Added box examples in C++ and Python
+    * [Pull request #584](https://github.com/gazebosim/gz-math/pull/584)
+
+1. Check for 0 stddev when generating a random number using normal distribution
+    * [Pull request #615](https://github.com/gazebosim/gz-math/pull/615)
+
+1. Clean up nested namespaces
+    * [Pull request #603](https://github.com/gazebosim/gz-math/pull/603)
+
 ### Gazebo Math 7.5.0 (2024-06-18)
 
 1. Backport: Adding cone primitives.


### PR DESCRIPTION
# ➡️  Forward port

Port `gz-math7 ` ➡️  `gz-math8`

Branch comparison: https://github.com/gazebosim/gz-math/compare/gz-math8...gz-math7

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)