### PR TITLE
Add missing dependencies to targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,8 +58,8 @@ cc_library(
     hdrs = ["include/gz/math/Angle.hh"],
     includes = ["include"],
     deps = [
-        ":Helpers",
         ":Config",
+        ":Helpers",
     ],
 )
 
@@ -1018,8 +1018,8 @@ cc_library(
     hdrs = ["include/gz/math/SphericalCoordinates.hh"],
     includes = ["include"],
     deps = [
-        ":Config",
         ":Angle",
+        ":Config",
         ":CoordinateVector3",
         ":Helpers",
         ":Matrix3",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -196,6 +196,8 @@ cc_library(
     includes = ["include"],
     deps = [
         ":Angle",
+        ":Config",
+        ":Helpers",
         ":Vector3",
         "@gz-utils//:ImplPtr",
     ],
@@ -932,6 +934,7 @@ cc_library(
     hdrs = ["include/gz/math/SemanticVersion.hh"],
     includes = ["include"],
     deps = [
+        ":Config",
         ":Helpers",
         "@gz-utils//:ImplPtr",
     ],
@@ -1015,10 +1018,12 @@ cc_library(
     hdrs = ["include/gz/math/SphericalCoordinates.hh"],
     includes = ["include"],
     deps = [
+        ":Config",
         ":Angle",
         ":CoordinateVector3",
         ":Helpers",
         ":Matrix3",
+        ":Vector3",
         "@gz-utils//:ImplPtr",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,7 +57,10 @@ cc_library(
     srcs = ["src/Angle.cc"],
     hdrs = ["include/gz/math/Angle.hh"],
     includes = ["include"],
-    deps = [":Helpers"],
+    deps = [
+        ":Helpers",
+        ":Config",
+    ],
 )
 
 cc_test(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -147,6 +147,7 @@ cc_library(
     ],
     includes = ["include"],
     deps = [
+        ":Config",
         ":Helpers",
         ":Vector3",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,6 +82,9 @@ cc_library(
         ":Helpers",
         ":Line3",
         ":MassMatrix3",
+        ":Material",
+        ":Vector3",
+        "@gz-utils//:ImplPtr",
     ],
 )
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes missing Bazel dependencies to make gz-math work with bzlmod

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
