### PR TITLE
Specify template for Vector2 in Vector2_TEST

### DIFF
--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -170,9 +170,9 @@ TEST(Vector2Test, Vector2)
 /////////////////////////////////////////////////
 TEST(Vector2Test, TestSum)
 {
-  math::Vector2d vec1(0, 0);
-  math::Vector2d vec2(1.0, 2.5);
-  math::Vector2d vec3(-2, -4);
+  math::Vector2i vec1(0, 0);
+  math::Vector2f vec2(1.0, 2.5);
+  math::Vector2i vec3(-2, -4);
 
   int sum1 = vec1.Sum();
   float sum2 = vec2.Sum();

--- a/src/Vector2_TEST.cc
+++ b/src/Vector2_TEST.cc
@@ -170,9 +170,9 @@ TEST(Vector2Test, Vector2)
 /////////////////////////////////////////////////
 TEST(Vector2Test, TestSum)
 {
-  math::Vector2 vec1(0, 0);
-  math::Vector2 vec2(1.0, 2.5);
-  math::Vector2 vec3(-2, -4);
+  math::Vector2d vec1(0, 0);
+  math::Vector2d vec2(1.0, 2.5);
+  math::Vector2d vec3(-2, -4);
 
   int sum1 = vec1.Sum();
   float sum2 = vec2.Sum();


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Small fix in Vector2_TEST where for some versions of `gcc` in Bazel build, automatic template type deduction fails causing build to fail.
e.g. https://buildkite.com/bazel/bcr-presubmit/builds/8774#01932597-4017-45bd-8002-7cca347166e2/254-432

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

