### PR TITLE
Enable header layering checks for bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,4 +10,6 @@ build --strip=never
 build --strict_system_includes
 build --fission=dbg
 build --features=per_object_debug_info
+
+# Enable header processing, required for layering checks with parse_header.
 build --process_headers_in_dependencies

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,3 +10,4 @@ build --strip=never
 build --strict_system_includes
 build --fission=dbg
 build --features=per_object_debug_info
+build --process_headers_in_dependencies

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,10 @@ load("@rules_license//rules:license.bzl", "license")
 package(
     default_applicable_licenses = [":license"],
     default_visibility = ["//visibility:public"],
-    features = ["layering_check"],
+    features = [
+        "layering_check",
+        "parse_headers",
+    ],
 )
 
 license(
@@ -583,6 +586,10 @@ cc_library(
     name = "MaterialType",
     hdrs = ["include/gz/math/MaterialType.hh"],
     includes = ["include"],
+    deps = [
+        ":Config",
+        ":Export",
+    ],
 )
 
 cc_library(
@@ -689,6 +696,9 @@ cc_library(
     hdrs = ["include/gz/math/MovingWindowFilter.hh"],
     includes = ["include"],
     deps = [
+        ":Config",
+        ":Export",
+        ":Vector3",
         "@gz-utils//:SuppressWarning",
     ],
 )
@@ -748,6 +758,9 @@ cc_library(
     name = "PiecewiseScalarField3",
     hdrs = ["include/gz/math/PiecewiseScalarField3.hh"],
     includes = ["include"],
+    deps = [
+        ":Region3",
+    ],
 )
 
 cc_test(

--- a/eigen3/BUILD.bazel
+++ b/eigen3/BUILD.bazel
@@ -2,6 +2,10 @@ load("@rules_license//rules:license.bzl", "license")
 
 package(
     default_applicable_licenses = ["//:license"],
+    features = [
+        "layering_check",
+        "parse_headers",
+    ],
 )
 
 license(

--- a/include/gz/math/detail/Box.hh
+++ b/include/gz/math/detail/Box.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_MATH_DETAIL_BOX_HH_
 #define GZ_MATH_DETAIL_BOX_HH_
 
+#include "gz/math/Box.hh"
 #include "gz/math/Triangle3.hh"
 
 #include <optional>

--- a/include/gz/math/detail/Capsule.hh
+++ b/include/gz/math/detail/Capsule.hh
@@ -19,6 +19,7 @@
 
 #include <limits>
 #include <optional>
+#include <gz/math/Capsule.hh>
 #include <gz/math/Helpers.hh>
 #include <gz/math/Inertial.hh>
 

--- a/include/gz/math/detail/Cone.hh
+++ b/include/gz/math/detail/Cone.hh
@@ -20,6 +20,7 @@
 #define GZ_MATH_DETAIL_CONE_HH_
 
 #include <optional>
+#include "gz/math/Cone.hh"
 
 namespace gz::math
 {

--- a/include/gz/math/detail/Cylinder.hh
+++ b/include/gz/math/detail/Cylinder.hh
@@ -18,6 +18,7 @@
 #define GZ_MATH_DETAIL_CYLINDER_HH_
 
 #include <optional>
+#include "gz/math/Cylinder.hh"
 
 namespace gz::math
 {

--- a/include/gz/math/detail/Ellipsoid.hh
+++ b/include/gz/math/detail/Ellipsoid.hh
@@ -19,6 +19,7 @@
 
 #include <limits>
 #include <optional>
+#include "gz/math/Ellipsoid.hh"
 #include <gz/math/Helpers.hh>
 #include <gz/math/Inertial.hh>
 

--- a/src/KmeansPrivate.hh
+++ b/src/KmeansPrivate.hh
@@ -21,6 +21,7 @@
 #include <gz/math/Vector3.hh>
 #include <gz/math/Helpers.hh>
 #include <gz/math/config.hh>
+#include <gz/math/Kmeans.hh>
 
 namespace gz
 {

--- a/src/MaterialType.hh
+++ b/src/MaterialType.hh
@@ -20,6 +20,8 @@
 #include <array>
 #include <utility>
 
+#include "gz/math/Material.hh"
+
 using namespace gz;
 using namespace math;
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Enables `parse_header` and `process_headers_in_dependencies` checks for Bazel build to flag missing dependencies earlier.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

