### PR TITLE
Unify Python3_Development_FOUND checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ else()
   endif()
 
   if (NOT Python3_Development_FOUND)
-    GZ_BUILD_WARNING("Python3 is missing: Python interfaces are disabled.")
     message (STATUS "Searching for Python3 - not found.")
   else()
     message (STATUS "Searching for Python3 - found version ${Python3_VERSION}.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,10 +18,12 @@ gz_build_tests(TYPE UNIT SOURCES ${gtest_sources})
 add_subdirectory(graph)
 
 # Bindings subdirectories
-if (Python3_Development_FOUND AND NOT SKIP_PYBIND11)
-  add_subdirectory(python_pybind11)
-else()
-  message(WARNING "Python development libraries are missing: Python interfaces are disabled.")
+if (NOT SKIP_PYBIND11)
+  if (Python3_Development_FOUND)
+    add_subdirectory(python_pybind11)
+  else()
+    message(WARNING "Python development libraries are missing: Python interfaces are disabled.")
+  endif()
 endif()
 
 if (SWIG_FOUND AND NOT SKIP_SWIG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,8 @@ add_subdirectory(graph)
 # Bindings subdirectories
 if (Python3_Development_FOUND AND NOT SKIP_PYBIND11)
   add_subdirectory(python_pybind11)
+else()
+  message(WARNING "Python development libraries are missing: Python interfaces are disabled.")
 endif()
 
 if (SWIG_FOUND AND NOT SKIP_SWIG)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes hidden warnings when python development libraries are not found, backport of https://github.com/gazebosim/gz-math/pull/662

## Summary

The value of Python3_Development_FOUND may change if other code paths call find_package(Python3), so move the warning to be co-located with the add_subdirectory call. Otherwise python bindings may be silently ignored.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
