### PR TITLE
feat: Add AxisAlignedBox conversion helpers

### DIFF
--- a/include/gz/math/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/AxisAlignedBoxHelpers.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,49 +25,46 @@
 
 namespace gz::math
 {
-   // Inline bracket to help doxygen filtering.
-   inline namespace GZ_MATH_VERSION_NAMESPACE {
+  // Inline bracket to help doxygen filtering.
+  inline namespace GZ_MATH_VERSION_NAMESPACE {
+    /// \class AxisAlignedBoxHelpers
+    ///        AxisAlignedBoxHelpers.hh gz/math/AxisAlignedBoxHelpers.hh
+    /// \brief A utility class to assist in
+    ///        converting different geometric shapes
+    ///        into AxisAlignedBox representations.
+    ///
+    /// This class provides static methods for converting different types of 3D
+    /// shapes, such as Box, Sphere, Capsule, and Cylinder, into AxisAlignedBox
+    /// objects.
+    template<typename Precision>
+    class AxisAlignedBoxHelpers
+    {
+    public:
+        /// \brief Convert a Box to an AxisAlignedBox.
+        /// \param[in] _box The Box to be converted.
+        /// \return An AxisAlignedBox that fully contains the given Box.
+        static AxisAlignedBox ConvertToAxisAlignedBox(
+          const Box<Precision> &_box);
 
-      /// \class AxisAlignedBoxHelpers
-      ///        AxisAlignedBoxHelpers.hh gz/math/AxisAlignedBoxHelpers.hh
-      /// \brief A utility class to assist in
-      ///        converting different geometric shapes
-      ///        into AxisAlignedBox representations.
-      ///
-      /// This class provides static methods for
-      /// converting different types of 3D
-      /// shapes, such as Box, Sphere, Capsule,
-      /// and Cylinder, into AxisAlignedBox
-      /// objects.
-      template<typename Precision>
-      class AxisAlignedBoxHelpers
-      {
-      public:
-         /// \brief Convert a Box to an AxisAlignedBox.
-         /// \param[in] _box The Box to be converted.
-         /// \return An AxisAlignedBox that fully contains the given Box.
-         static AxisAlignedBox ConvertToAxisAlignedBox(
-            const Box<Precision> &_box);
+        /// \brief Convert a Sphere to an AxisAlignedBox.
+        /// \param[in] _sphere The Sphere to be converted.
+        /// \return An AxisAlignedBox that fully contains the given Sphere.
+        static AxisAlignedBox ConvertToAxisAlignedBox(
+          const Sphere<Precision> &_sphere);
 
-         /// \brief Convert a Sphere to an AxisAlignedBox.
-         /// \param[in] _sphere The Sphere to be converted.
-         /// \return An AxisAlignedBox that fully contains the given Sphere.
-         static AxisAlignedBox ConvertToAxisAlignedBox(
-            const Sphere<Precision> &_sphere);
+        /// \brief Convert a Capsule to an AxisAlignedBox.
+        /// \param[in] _capsule The Capsule to be converted.
+        /// \return An AxisAlignedBox that fully contains the given Capsule.
+        static AxisAlignedBox ConvertToAxisAlignedBox(
+          const Capsule<Precision> &_capsule);
 
-         /// \brief Convert a Capsule to an AxisAlignedBox.
-         /// \param[in] _capsule The Capsule to be converted.
-         /// \return An AxisAlignedBox that fully contains the given Capsule.
-         static AxisAlignedBox ConvertToAxisAlignedBox(
-            const Capsule<Precision> &_capsule);
-
-         /// \brief Convert a Cylinder to an AxisAlignedBox.
-         /// \param[in] _cylinder The Cylinder to be converted.
-         /// \return An AxisAlignedBox that fully contains the given Cylinder.
-         static AxisAlignedBox ConvertToAxisAlignedBox(
-            const Cylinder<Precision> &_cylinder);
-      };
-   }
+        /// \brief Convert a Cylinder to an AxisAlignedBox.
+        /// \param[in] _cylinder The Cylinder to be converted.
+        /// \return An AxisAlignedBox that fully contains the given Cylinder.
+        static AxisAlignedBox ConvertToAxisAlignedBox(
+          const Cylinder<Precision> &_cylinder);
+    };
+  }
 }  // namespace gz::math
 
 #include "gz/math/detail/AxisAlignedBoxHelpers.hh"

--- a/include/gz/math/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/AxisAlignedBoxHelpers.hh
@@ -27,13 +27,17 @@ namespace gz::math
 {
    // Inline bracket to help doxygen filtering.
    inline namespace GZ_MATH_VERSION_NAMESPACE {
-      
-      /// \class AxisAlignedBoxHelpers AxisAlignedBoxHelpers.hh gz/math/AxisAlignedBoxHelpers.hh
-      /// \brief A utility class to assist in converting different geometric shapes
+
+      /// \class AxisAlignedBoxHelpers
+      ///        AxisAlignedBoxHelpers.hh gz/math/AxisAlignedBoxHelpers.hh
+      /// \brief A utility class to assist in
+      ///        converting different geometric shapes
       ///        into AxisAlignedBox representations.
       ///
-      /// This class provides static methods for converting different types of 3D
-      /// shapes, such as Box, Sphere, Capsule, and Cylinder, into AxisAlignedBox
+      /// This class provides static methods for
+      /// converting different types of 3D
+      /// shapes, such as Box, Sphere, Capsule,
+      /// and Cylinder, into AxisAlignedBox
       /// objects.
       template<typename Precision>
       class AxisAlignedBoxHelpers
@@ -42,22 +46,26 @@ namespace gz::math
          /// \brief Convert a Box to an AxisAlignedBox.
          /// \param[in] _box The Box to be converted.
          /// \return An AxisAlignedBox that fully contains the given Box.
-         static AxisAlignedBox ConvertToAxisAlignedBox(const Box<Precision> &_box);
+         static AxisAlignedBox ConvertToAxisAlignedBox(
+            const Box<Precision> &_box);
 
          /// \brief Convert a Sphere to an AxisAlignedBox.
          /// \param[in] _sphere The Sphere to be converted.
          /// \return An AxisAlignedBox that fully contains the given Sphere.
-         static AxisAlignedBox ConvertToAxisAlignedBox(const Sphere<Precision> &_sphere);
+         static AxisAlignedBox ConvertToAxisAlignedBox(
+            const Sphere<Precision> &_sphere);
 
          /// \brief Convert a Capsule to an AxisAlignedBox.
          /// \param[in] _capsule The Capsule to be converted.
          /// \return An AxisAlignedBox that fully contains the given Capsule.
-         static AxisAlignedBox ConvertToAxisAlignedBox(const Capsule<Precision> &_capsule);
+         static AxisAlignedBox ConvertToAxisAlignedBox(
+            const Capsule<Precision> &_capsule);
 
          /// \brief Convert a Cylinder to an AxisAlignedBox.
          /// \param[in] _cylinder The Cylinder to be converted.
          /// \return An AxisAlignedBox that fully contains the given Cylinder.
-         static AxisAlignedBox ConvertToAxisAlignedBox(const Cylinder<Precision> &_cylinder);
+         static AxisAlignedBox ConvertToAxisAlignedBox(
+            const Cylinder<Precision> &_cylinder);
       };
    }
 }  // namespace gz::math

--- a/include/gz/math/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/AxisAlignedBoxHelpers.hh
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GZ_MATH_AXISALIGNEDBOXHELPERS_HH_
+#define GZ_MATH_AXISALIGNEDBOXHELPERS_HH_
+
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/Box.hh>
+#include <gz/math/Sphere.hh>
+#include <gz/math/Capsule.hh>
+#include <gz/math/Cylinder.hh>
+
+namespace gz::math
+{
+   // Inline bracket to help doxygen filtering.
+   inline namespace GZ_MATH_VERSION_NAMESPACE {
+      
+      /// \class AxisAlignedBoxHelpers AxisAlignedBoxHelpers.hh gz/math/AxisAlignedBoxHelpers.hh
+      /// \brief A utility class to assist in converting different geometric shapes
+      ///        into AxisAlignedBox representations.
+      ///
+      /// This class provides static methods for converting different types of 3D
+      /// shapes, such as Box, Sphere, Capsule, and Cylinder, into AxisAlignedBox
+      /// objects.
+      template<typename Precision>
+      class AxisAlignedBoxHelpers
+      {
+      public:
+         /// \brief Convert a Box to an AxisAlignedBox.
+         /// \param[in] _box The Box to be converted.
+         /// \return An AxisAlignedBox that fully contains the given Box.
+         static AxisAlignedBox ConvertToAxisAlignedBox(const Box<Precision> &_box);
+
+         /// \brief Convert a Sphere to an AxisAlignedBox.
+         /// \param[in] _sphere The Sphere to be converted.
+         /// \return An AxisAlignedBox that fully contains the given Sphere.
+         static AxisAlignedBox ConvertToAxisAlignedBox(const Sphere<Precision> &_sphere);
+
+         /// \brief Convert a Capsule to an AxisAlignedBox.
+         /// \param[in] _capsule The Capsule to be converted.
+         /// \return An AxisAlignedBox that fully contains the given Capsule.
+         static AxisAlignedBox ConvertToAxisAlignedBox(const Capsule<Precision> &_capsule);
+
+         /// \brief Convert a Cylinder to an AxisAlignedBox.
+         /// \param[in] _cylinder The Cylinder to be converted.
+         /// \return An AxisAlignedBox that fully contains the given Cylinder.
+         static AxisAlignedBox ConvertToAxisAlignedBox(const Cylinder<Precision> &_cylinder);
+      };
+   }
+}  // namespace gz::math
+
+#include "gz/math/detail/AxisAlignedBoxHelpers.hh"
+#endif  // GZ_MATH_AXISALIGNEDBOXHELPERS_HH_

--- a/include/gz/math/detail/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/detail/AxisAlignedBoxHelpers.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/gz/math/detail/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/detail/AxisAlignedBoxHelpers.hh
@@ -27,77 +27,96 @@ namespace gz::math
 {
     //////////////////////////////////////////////////
     /// \brief Converts a Box object to an AxisAlignedBox.
-    /// 
-    /// This function takes a Box instance and computes its corresponding AxisAlignedBox,
-    /// which is centered at the origin and has half the size of the original box in all dimensions.
-    /// 
+    ///
+    /// This function takes a Box instance
+    /// and computes its corresponding
+    /// AxisAlignedBox, which is centered at the
+    /// origin and has half the size
+    /// of the original box in all dimensions.
+    ///
     /// \tparam Precision The numeric precision type.
     /// \param[in] _box The Box object to be converted.
     /// \return The corresponding AxisAlignedBox.
     //////////////////////////////////////////////////
     template<typename Precision>
-    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Box<Precision> &_box)
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(
+        const Box<Precision> &_box)
     {
         Vector3<Precision> size = _box.Size();
-        return AxisAlignedBox(Vector3<Precision>(-size.X() / 2, -size.Y() / 2, -size.Z() / 2),
-                                Vector3<Precision>(size.X() / 2, size.Y() / 2, size.Z() / 2));
+        return AxisAlignedBox(
+            Vector3<Precision>(-size.X() / 2, -size.Y() / 2, -size.Z() / 2),
+            Vector3<Precision>(size.X() / 2, size.Y() / 2, size.Z() / 2));
     }
 
     //////////////////////////////////////////////////
     /// \brief Converts a Sphere object to an AxisAlignedBox.
-    /// 
-    /// This function takes a Sphere instance and computes its corresponding AxisAlignedBox,
-    /// which is a cube enclosing the sphere with side lengths equal to twice the sphere's radius.
-    /// 
+    ///
+    /// This function takes a Sphere instance
+    /// and computes its corresponding
+    /// AxisAlignedBox, which is a cube enclosing
+    /// the sphere with side lengths
+    /// equal to twice the sphere's radius.
+    ///
     /// \tparam Precision The numeric precision type.
     /// \param[in] _sphere The Sphere object to be converted.
     /// \return The corresponding AxisAlignedBox.
     //////////////////////////////////////////////////
     template<typename Precision>
-    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Sphere<Precision> &_sphere)
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(
+        const Sphere<Precision> &_sphere)
     {
         Precision radius = _sphere.Radius();
-        return AxisAlignedBox(Vector3<Precision>(-radius, -radius, -radius),
-                                Vector3<Precision>(radius, radius, radius));
+        return AxisAlignedBox(
+            Vector3<Precision>(-radius, -radius, -radius),
+            Vector3<Precision>(radius, radius, radius));
     }
 
     //////////////////////////////////////////////////
     /// \brief Converts a Capsule object to an AxisAlignedBox.
-    /// 
-    /// This function takes a Capsule instance and computes its corresponding AxisAlignedBox,
-    /// which fully encloses the capsule by considering both its cylindrical body and hemispherical ends.
-    /// 
+    ///
+    /// This function takes a Capsule instance
+    /// and computes its corresponding
+    /// AxisAlignedBox, which fully encloses the
+    /// capsule by considering both
+    /// its cylindrical body and hemispherical ends.
+    ///
     /// \tparam Precision The numeric precision type.
     /// \param[in] _capsule The Capsule object to be converted.
     /// \return The corresponding AxisAlignedBox.
     //////////////////////////////////////////////////
     template<typename Precision>
-    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Capsule<Precision> &_capsule)
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(
+        const Capsule<Precision> &_capsule)
     {
         Precision radius = _capsule.Radius();
         Precision length = _capsule.Length();
-        return AxisAlignedBox(Vector3<Precision>(-radius, -radius, -length / 2 - radius),
-                                Vector3<Precision>(radius, radius, length / 2 + radius));
+        return AxisAlignedBox(
+            Vector3<Precision>(-radius, -radius, -length / 2 - radius),
+            Vector3<Precision>(radius, radius, length / 2 + radius));
     }
-    
+
     //////////////////////////////////////////////////
     /// \brief Converts a Cylinder object to an AxisAlignedBox.
-    /// 
-    /// This function takes a Cylinder instance and computes its corresponding AxisAlignedBox,
-    /// which fully encloses the cylinder based on its radius and height.
-    /// 
+    ///
+    /// This function takes a Cylinder instance and computes its corresponding
+    /// AxisAlignedBox, which fully encloses the cylinder based on its radius
+    /// and height.
+    ///
     /// \tparam Precision The numeric precision type.
     /// \param[in] _cylinder The Cylinder object to be converted.
     /// \return The corresponding AxisAlignedBox.
     //////////////////////////////////////////////////
     template<typename Precision>
-    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Cylinder<Precision> &_cylinder)
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(
+        const Cylinder<Precision> &_cylinder)
     {
         Precision radius = _cylinder.Radius();
         Precision length = _cylinder.Length();
-        return AxisAlignedBox(Vector3<Precision>(-radius, -radius, -length / 2),
-                                Vector3<Precision>(radius, radius, length / 2));
+        return AxisAlignedBox(
+            Vector3<Precision>(-radius, -radius, -length / 2),
+            Vector3<Precision>(radius, radius, length / 2));
     }
 
 }  // namespace gz::math
+
 #endif  // GZ_MATH_DETAIL_AXISALIGNEDBOXHELPERS_HH_

--- a/include/gz/math/detail/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/detail/AxisAlignedBoxHelpers.hh
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GZ_MATH_DETAIL_AXISALIGNEDBOXHELPERS_HH_
+#define GZ_MATH_DETAIL_AXISALIGNEDBOXHELPERS_HH_
+
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/AxisAlignedBoxHelpers.hh>
+#include <gz/math/Box.hh>
+#include <gz/math/Sphere.hh>
+#include <gz/math/Capsule.hh>
+#include <gz/math/Cylinder.hh>
+
+namespace gz::math
+{
+    //////////////////////////////////////////////////
+    /// \brief Converts a Box object to an AxisAlignedBox.
+    /// 
+    /// This function takes a Box instance and computes its corresponding AxisAlignedBox,
+    /// which is centered at the origin and has half the size of the original box in all dimensions.
+    /// 
+    /// \tparam Precision The numeric precision type.
+    /// \param[in] _box The Box object to be converted.
+    /// \return The corresponding AxisAlignedBox.
+    //////////////////////////////////////////////////
+    template<typename Precision>
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Box<Precision> &_box)
+    {
+        Vector3<Precision> size = _box.Size();
+        return AxisAlignedBox(Vector3<Precision>(-size.X() / 2, -size.Y() / 2, -size.Z() / 2),
+                                Vector3<Precision>(size.X() / 2, size.Y() / 2, size.Z() / 2));
+    }
+
+    //////////////////////////////////////////////////
+    /// \brief Converts a Sphere object to an AxisAlignedBox.
+    /// 
+    /// This function takes a Sphere instance and computes its corresponding AxisAlignedBox,
+    /// which is a cube enclosing the sphere with side lengths equal to twice the sphere's radius.
+    /// 
+    /// \tparam Precision The numeric precision type.
+    /// \param[in] _sphere The Sphere object to be converted.
+    /// \return The corresponding AxisAlignedBox.
+    //////////////////////////////////////////////////
+    template<typename Precision>
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Sphere<Precision> &_sphere)
+    {
+        Precision radius = _sphere.Radius();
+        return AxisAlignedBox(Vector3<Precision>(-radius, -radius, -radius),
+                                Vector3<Precision>(radius, radius, radius));
+    }
+
+    //////////////////////////////////////////////////
+    /// \brief Converts a Capsule object to an AxisAlignedBox.
+    /// 
+    /// This function takes a Capsule instance and computes its corresponding AxisAlignedBox,
+    /// which fully encloses the capsule by considering both its cylindrical body and hemispherical ends.
+    /// 
+    /// \tparam Precision The numeric precision type.
+    /// \param[in] _capsule The Capsule object to be converted.
+    /// \return The corresponding AxisAlignedBox.
+    //////////////////////////////////////////////////
+    template<typename Precision>
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Capsule<Precision> &_capsule)
+    {
+        Precision radius = _capsule.Radius();
+        Precision length = _capsule.Length();
+        return AxisAlignedBox(Vector3<Precision>(-radius, -radius, -length / 2 - radius),
+                                Vector3<Precision>(radius, radius, length / 2 + radius));
+    }
+    
+    //////////////////////////////////////////////////
+    /// \brief Converts a Cylinder object to an AxisAlignedBox.
+    /// 
+    /// This function takes a Cylinder instance and computes its corresponding AxisAlignedBox,
+    /// which fully encloses the cylinder based on its radius and height.
+    /// 
+    /// \tparam Precision The numeric precision type.
+    /// \param[in] _cylinder The Cylinder object to be converted.
+    /// \return The corresponding AxisAlignedBox.
+    //////////////////////////////////////////////////
+    template<typename Precision>
+    AxisAlignedBox AxisAlignedBoxHelpers<Precision>::ConvertToAxisAlignedBox(const Cylinder<Precision> &_cylinder)
+    {
+        Precision radius = _cylinder.Radius();
+        Precision length = _cylinder.Length();
+        return AxisAlignedBox(Vector3<Precision>(-radius, -radius, -length / 2),
+                                Vector3<Precision>(radius, radius, length / 2));
+    }
+
+}  // namespace gz::math
+#endif  // GZ_MATH_DETAIL_AXISALIGNEDBOXHELPERS_HH_

--- a/include/gz/math/detail/AxisAlignedBoxHelpers.hh
+++ b/include/gz/math/detail/AxisAlignedBoxHelpers.hh
@@ -16,6 +16,7 @@
 #ifndef GZ_MATH_DETAIL_AXISALIGNEDBOXHELPERS_HH_
 #define GZ_MATH_DETAIL_AXISALIGNEDBOXHELPERS_HH_
 
+#include <gz/math/Vector3.hh>
 #include <gz/math/AxisAlignedBox.hh>
 #include <gz/math/AxisAlignedBoxHelpers.hh>
 #include <gz/math/Box.hh>

--- a/src/AxisAlignedBoxHelpers_TEST.cc
+++ b/src/AxisAlignedBoxHelpers_TEST.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Open Source Robotics Foundation
+ * Copyright (C) 2025 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/AxisAlignedBoxHelpers_TEST.cc
+++ b/src/AxisAlignedBoxHelpers_TEST.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "gz/math/Box.hh"
+#include "gz/math/Sphere.hh"
+#include "gz/math/Capsule.hh"
+#include "gz/math/Cylinder.hh"
+#include "gz/math/AxisAlignedBox.hh"
+#include "gz/math/AxisAlignedBoxHelpers.hh"
+
+using namespace gz;
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertBox)
+{
+  math::Box<double> box(2.0, 4.0, 6.0);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(-1.0, -2.0, -3.0));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(1.0, 2.0, 3.0));
+}
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertSphere)
+{
+  math::Sphered sphere(3.0);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(sphere);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(-3.0, -3.0, -3.0));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(3.0, 3.0, 3.0));
+}
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertCapsule)
+{
+  math::Capsuled capsule(5.0, 2.0);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(capsule);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(-2.0, -2.0, -4.5));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(2.0, 2.0, 4.5));
+}
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertCylinder)
+{
+  math::Cylinderd cylinder(5.0, 2.0);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(cylinder);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(-2.0, -2.0, -2.5));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(2.0, 2.0, 2.5));
+}
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertZeroSizeBox)
+{
+  math::Box<double> box(0.0, 0.0, 0.0);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(0.0, 0.0, 0.0));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(0.0, 0.0, 0.0));
+}
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertNegativeSizeBox)
+{
+  math::Box<double> box(-2.0, -4.0, -6.0);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(-1.0, -2.0, -3.0));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(1.0, 2.0, 3.0));
+}
+
+//////////////////////////////////////////////////
+TEST(AxisAlignedBoxHelpersTest, ConvertLargeSphere)
+{
+  math::Sphered sphere(1e6);
+  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(sphere);
+  EXPECT_EQ(aabb.Min(), math::Vector3d(-1e6, -1e6, -1e6));
+  EXPECT_EQ(aabb.Max(), math::Vector3d(1e6, 1e6, 1e6));
+}

--- a/src/AxisAlignedBoxHelpers_TEST.cc
+++ b/src/AxisAlignedBoxHelpers_TEST.cc
@@ -29,7 +29,8 @@ using namespace gz;
 TEST(AxisAlignedBoxHelpersTest, ConvertBox)
 {
   math::Box<double> box(2.0, 4.0, 6.0);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
+  math::AxisAlignedBox aabb =
+          math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
   EXPECT_EQ(aabb.Min(), math::Vector3d(-1.0, -2.0, -3.0));
   EXPECT_EQ(aabb.Max(), math::Vector3d(1.0, 2.0, 3.0));
 }
@@ -38,7 +39,8 @@ TEST(AxisAlignedBoxHelpersTest, ConvertBox)
 TEST(AxisAlignedBoxHelpersTest, ConvertSphere)
 {
   math::Sphered sphere(3.0);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(sphere);
+  math::AxisAlignedBox aabb =
+      math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(sphere);
   EXPECT_EQ(aabb.Min(), math::Vector3d(-3.0, -3.0, -3.0));
   EXPECT_EQ(aabb.Max(), math::Vector3d(3.0, 3.0, 3.0));
 }
@@ -47,7 +49,8 @@ TEST(AxisAlignedBoxHelpersTest, ConvertSphere)
 TEST(AxisAlignedBoxHelpersTest, ConvertCapsule)
 {
   math::Capsuled capsule(5.0, 2.0);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(capsule);
+  math::AxisAlignedBox aabb =
+      math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(capsule);
   EXPECT_EQ(aabb.Min(), math::Vector3d(-2.0, -2.0, -4.5));
   EXPECT_EQ(aabb.Max(), math::Vector3d(2.0, 2.0, 4.5));
 }
@@ -56,7 +59,8 @@ TEST(AxisAlignedBoxHelpersTest, ConvertCapsule)
 TEST(AxisAlignedBoxHelpersTest, ConvertCylinder)
 {
   math::Cylinderd cylinder(5.0, 2.0);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(cylinder);
+  math::AxisAlignedBox aabb =
+      math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(cylinder);
   EXPECT_EQ(aabb.Min(), math::Vector3d(-2.0, -2.0, -2.5));
   EXPECT_EQ(aabb.Max(), math::Vector3d(2.0, 2.0, 2.5));
 }
@@ -65,7 +69,8 @@ TEST(AxisAlignedBoxHelpersTest, ConvertCylinder)
 TEST(AxisAlignedBoxHelpersTest, ConvertZeroSizeBox)
 {
   math::Box<double> box(0.0, 0.0, 0.0);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
+  math::AxisAlignedBox aabb =
+      math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
   EXPECT_EQ(aabb.Min(), math::Vector3d(0.0, 0.0, 0.0));
   EXPECT_EQ(aabb.Max(), math::Vector3d(0.0, 0.0, 0.0));
 }
@@ -74,7 +79,8 @@ TEST(AxisAlignedBoxHelpersTest, ConvertZeroSizeBox)
 TEST(AxisAlignedBoxHelpersTest, ConvertNegativeSizeBox)
 {
   math::Box<double> box(-2.0, -4.0, -6.0);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
+  math::AxisAlignedBox aabb =
+      math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);
   EXPECT_EQ(aabb.Min(), math::Vector3d(-1.0, -2.0, -3.0));
   EXPECT_EQ(aabb.Max(), math::Vector3d(1.0, 2.0, 3.0));
 }
@@ -83,7 +89,8 @@ TEST(AxisAlignedBoxHelpersTest, ConvertNegativeSizeBox)
 TEST(AxisAlignedBoxHelpersTest, ConvertLargeSphere)
 {
   math::Sphered sphere(1e6);
-  math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(sphere);
+  math::AxisAlignedBox aabb =
+      math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(sphere);
   EXPECT_EQ(aabb.Min(), math::Vector3d(-1e6, -1e6, -1e6));
   EXPECT_EQ(aabb.Max(), math::Vector3d(1e6, 1e6, 1e6));
 }

--- a/src/python_pybind11/CMakeLists.txt
+++ b/src/python_pybind11/CMakeLists.txt
@@ -136,6 +136,7 @@ if (BUILD_TESTING)
   set(python_tests
     Angle_TEST
     AxisAlignedBox_TEST
+    AxisAlignedBoxHelpers_TEST
     Box_TEST
     Capsule_TEST
     Color_TEST

--- a/src/python_pybind11/src/AxisAlignedBoxHelpers.hh
+++ b/src/python_pybind11/src/AxisAlignedBoxHelpers.hh
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include <string>
+#include <gz/math/Box.hh>
+#include <gz/math/Sphere.hh>
+#include <gz/math/Capsule.hh>
+#include <gz/math/Cylinder.hh>
+#include <gz/math/AxisAlignedBox.hh>
+#include <gz/math/AxisAlignedBoxHelpers.hh>
+
+namespace py = pybind11;
+using namespace gz::math;
+
+namespace gz
+{
+namespace math
+{
+namespace python
+{
+/// Define a pybind11 wrapper for a gz::math::AxisAlignedBoxHelpers
+/**
+ * \param[in] module a pybind11 module to add the definition to
+ * \param[in] typestr name of the type used by Python
+ */
+template<typename T>
+void defineMathAxisAlignedBoxHelpers(
+    py::module &m,
+    const std::string &typestr)
+{
+    using Class = gz::math::AxisAlignedBoxHelpers<T>;
+    std::string pyclass_name = typestr;
+    py::class_<Class>(m,
+                pyclass_name.c_str(),
+                py::buffer_protocol(),
+                py::dynamic_attr())
+    .def("ConvertToAxisAlignedBox",
+        [](const py::object &shape) -> AxisAlignedBox {
+            if (py::isinstance<Box<T>>(shape)) {
+                return AxisAlignedBoxHelpers<T>::ConvertToAxisAlignedBox(
+                    shape.cast<Box<T>>());
+            } else if (py::isinstance<Sphere<T>>(shape)) {
+                return AxisAlignedBoxHelpers<T>::ConvertToAxisAlignedBox(
+                    shape.cast<Sphere<T>>());
+            } else if (py::isinstance<Capsule<T>>(shape)) {
+                return AxisAlignedBoxHelpers<T>::ConvertToAxisAlignedBox(
+                    shape.cast<Capsule<T>>());
+            } else if (py::isinstance<Cylinder<T>>(shape)) {
+                return AxisAlignedBoxHelpers<T>::ConvertToAxisAlignedBox(
+                    shape.cast<Cylinder<T>>());
+            } else {
+                throw std::runtime_error("Unsupported shape type");
+            }
+        },
+        "Convert a shape to an AxisAlignedBox");
+}
+}  // namespace python
+}  // namespace math
+}  // namespace gz

--- a/src/python_pybind11/src/_gz_math_pybind11.cc
+++ b/src/python_pybind11/src/_gz_math_pybind11.cc
@@ -16,6 +16,7 @@
 
 #include "Angle.hh"
 #include "AxisAlignedBox.hh"
+#include "AxisAlignedBoxHelpers.hh"
 #include "Box.hh"
 #include "Capsule.hh"
 #include "Color.hh"
@@ -73,6 +74,9 @@ PYBIND11_MODULE(BINDINGS_MODULE_NAME, m)
   gz::math::python::defineMathAngle(m, "Angle");
 
   gz::math::python::defineMathAxisAlignedBox(m, "AxisAlignedBox");
+
+  gz::math::python::defineMathAxisAlignedBoxHelpers<double>(
+    m, "AxisAlignedBoxHelpers");
 
   gz::math::python::defineMathCapsule(m, "Capsule");
 

--- a/src/python_pybind11/test/AxisAlignedBoxHelpers_TEST.py
+++ b/src/python_pybind11/test/AxisAlignedBoxHelpers_TEST.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2025 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from gz.math8 import Boxd, Sphered, Capsuled, Cylinderd, AxisAlignedBoxHelpers, Vector3d
+
+class TestAxisAlignedBoxHelpers(unittest.TestCase):
+    # Basic Box
+    def test_convert_box(self):
+        box = Boxd(2.0, 4.0, 6.0)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(box)
+        self.assertEqual(aabb.min(), Vector3d(-1.0, -2.0, -3.0))
+        self.assertEqual(aabb.max(), Vector3d(1.0, 2.0, 3.0))
+
+    # Basic Sphere
+    def test_convert_sphere(self):
+        sphere = Sphered(3.0)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(sphere)
+        self.assertEqual(aabb.min(), Vector3d(-3.0, -3.0, -3.0))
+        self.assertEqual(aabb.max(), Vector3d(3.0, 3.0, 3.0))
+
+    # Basic Capsule
+    def test_convert_capsule(self):
+        capsule = Capsuled(5.0, 2.0)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(capsule)
+        self.assertEqual(aabb.min(), Vector3d(-2.0, -2.0, -4.5))
+        self.assertEqual(aabb.max(), Vector3d(2.0, 2.0, 4.5))
+
+    # Basic Cylinder
+    def test_convert_cylinder(self):
+        cylinder = Cylinderd(5.0, 2.0)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(cylinder)
+        self.assertEqual(aabb.min(), Vector3d(-2.0, -2.0, -2.5))
+        self.assertEqual(aabb.max(), Vector3d(2.0, 2.0, 2.5))
+
+    # Zero-Sized Box
+    def test_convert_zero_size_box(self):
+        box = Boxd(0.0, 0.0, 0.0)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(box)
+        self.assertEqual(aabb.min(), Vector3d(0.0, 0.0, 0.0))
+        self.assertEqual(aabb.max(), Vector3d(0.0, 0.0, 0.0))
+
+    # Negative-Sized Box
+    def test_convert_negative_size_box(self):
+        box = Boxd(-2.0, -4.0, -6.0)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(box)
+        self.assertEqual(aabb.min(), Vector3d(-1.0, -2.0, -3.0))
+        self.assertEqual(aabb.max(), Vector3d(1.0, 2.0, 3.0))
+
+    # Large Sphere
+    def test_convert_large_sphere(self):
+        sphere = Sphered(1e6)
+        aabb = AxisAlignedBoxHelpers.ConvertToAxisAlignedBox(sphere)
+        self.assertEqual(aabb.min(), Vector3d(-1e6, -1e6, -1e6))
+        self.assertEqual(aabb.max(), Vector3d(1e6, 1e6, 1e6))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds helper functions to create AxisAlignedBox from shapes Origin shapes: Box, Sphere, Capsure, Cylinder

# 🎉 New feature

Closes #666 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Implementation of static helper functions in `gz::math::AxisAlignedBoxHelpers` to convert shape objects (Box, Sphere, Capsule, Cylinder) into AxisAlignedBox objects.

I have tried to write the functions in more or less the same format as other files. Since, the functions are template functions, I have kept their implementation in `gz/math/detail/AxisAlignedBoxHelpers.hh` and the declarations in `gz/math/AxisAlignedBoxHelpers.hh`.

I have also written comments in the same style as other files.

Also, I have added a few tests to check their correctness.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Testing can be done by creating a new shape:

`math::Box<double> box(2.0, 4.0, 6.0);`

Then, using the helper function:

`math::AxisAlignedBox aabb = math::AxisAlignedBoxHelpers<double>::ConvertToAxisAlignedBox(box);`

Then, can call functions like:

`aabb.Min()`

The output would be: `Vector3d(-1.0, -2.0, -3.0)`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

## Doubts
1. I am not sure if we need an example / tutorial for these helper functions. Kindly let me know if we do, I will add them.

2. Also, kindly let me know if the python bindings have to be updated and where do I update the documentation.