### PR TITLE
Test building python bindings in Ubuntu CI

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -15,4 +15,11 @@ cmake ..
 make
 ./graph_example
 
+# Compile python bindings
+cd $BUILD_DIR/../src/python_pybind11
+mkdir build;
+cd build;
+cmake ..;
+make;
+
 cd $BUILD_DIR


### PR DESCRIPTION
# 🦟 Bug fix

Adds CI testing for feature added in #636

## Summary

The ability to build python bindings separately
from the core library was added in #636 and is
currently used when building the homebrew
formulae but is not directly tested in CI.
This adds a quick test to the Ubuntu GitHub
actions workflow to compile the python bindings
after compiling example code.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
