### PR TITLE
Use Bazel Central Registry version of eigen

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "eigen", version = "3.4.0")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")  # workaround for https://github.com/bazelbuild/bazel-central-registry/issues/4355
 bazel_dep(name = "pybind11_bazel", version = "2.13.6")
 bazel_dep(name = "rules_python", version = "0.36.0")
 bazel_dep(name = "platforms", version = "0.0.11")


### PR DESCRIPTION
# 🦟 Bug fix

Fixes bazel CI, cherry-picked from #673

## Summary

The eigen 3.4.0 hash changed (see https://github.com/bazelbuild/bazel-central-registry/issues/4355), so this points to a more stable hash from the bazel central registry. Thanks to @j-rivero for the fix.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
