### PR TITLE
Fix bazel build errors with clang

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,6 +74,7 @@ cc_library(
     deps = [
         "@gz-utils//:ImplPtr",
         "@gz-utils//:NeverDestroyed",
+        "@gz-utils//:SuppressWarning",
     ],
 )
 
@@ -113,6 +114,7 @@ test_sources = glob(
             ":gz-math",
             "@googletest//:gtest",
             "@googletest//:gtest_main",
+            "@gz-utils//:SuppressWarning",
         ],
     )
     for src in test_sources


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes bazel build failures with clang of the form:
```
$ bazel build :all --action_env=CC=/usr/bin/clang --subcommands
...
ERROR: /usr/local/google/home/shameek/bazel-ws/gz-math/BUILD.bazel:86:12: Compiling src/Helpers_TEST.cc failed: (Exit 1): clang failed: error executing CppCompile command (from target //:Helpers_TEST) /usr/lib/llvm-19/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 68 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
src/Helpers_TEST.cc:27:10: error: module //:Helpers_TEST does not depend on a module exporting 'gz/utils/SuppressWarning.hh'
   27 | #include <gz/utils/SuppressWarning.hh>
      |          ^
1 error generated.
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
