### PR TITLE
[Bazel] Generate math.hh header file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
-load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
+load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header", "gz_include_header")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python:py_test.bzl", "py_test")
@@ -38,13 +38,22 @@ gz_configure_header(
     package_xml = "package.xml",
 )
 
-public_headers = glob(
+public_headers_no_gen = glob(
     include = [
         "include/gz/math/*.hh",
         "include/gz/math/detail/*.hh",
         "include/gz/math/graph/*.hh",
     ],
-) + [
+)
+
+gz_include_header(
+    name = "Include",
+    out = "include/gz/math.hh",
+    hdrs = public_headers_no_gen + ["include/gz/math/config.hh"],
+)
+
+public_headers = public_headers_no_gen + [
+    "include/gz/math.hh",
     "include/gz/math/Export.hh",
     "include/gz/math/config.hh",
 ]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "rules_python", version = "0.36.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_gazebo", version = "0.0.2")
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
 bazel_dep(name = "gz-utils")
 archive_override(
     module_name = "gz-utils",


### PR DESCRIPTION

# 🎉 New feature


## Summary

Generate `math.hh` that includes all other public headers in bazel build.

similar to https://github.com/gazebosim/sdformat/pull/1570


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

