### PR TITLE
python: suppress Pose3 deprecation warnings

### DIFF
--- a/src/python_pybind11/src/Pose3.hh
+++ b/src/python_pybind11/src/Pose3.hh
@@ -25,6 +25,7 @@
 #include <pybind11/operators.h>
 
 #include <gz/math/Pose3.hh>
+#include <gz/utils/SuppressWarning.hh>
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -67,11 +68,91 @@ void helpDefineMathPose3(py::module &m, const std::string &typestr)
     .def(py::init<T, T, T, T, T, T>())
     .def(py::init<T, T, T, T, T, T, T>())
     .def(py::init<const Class&>())
-    .def(py::self + py::self)
-    .def(py::self += py::self)
-    .def(-py::self)
-    .def(py::self - py::self)
-    .def(py::self -= py::self)
+    .def("__add__",
+         [](const Class &self, const gz::math::Pose3<T> &other)
+         {
+           PyErr_WarnEx(
+             PyExc_DeprecationWarning,
+             "The addition operator + is deprecated in favor of"
+             " the multiplication operator *, though the order of operands is"
+             " reversed (A + B = B * A). See Migration.md .",
+             1);
+           GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+           return self + other;
+           GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+         },
+         "DEPRECATED: The addition operator + is deprecated in favor of"
+         " the multiplication operator *, though the order of operands is"
+         " reversed (A + B = B * A). See Migration.md .",
+         py::is_operator())
+    .def("__iadd__",
+         [](Class &self, const gz::math::Pose3<T> &other)
+         {
+           PyErr_WarnEx(
+             PyExc_DeprecationWarning,
+             "The addition assignment operator += is deprecated in favor of"
+             " the multiplication assignment operator *=, though the order of"
+             " operands is reversed (A + B = B * A). See Migration.md .",
+             1);
+           GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+           self += other;
+           GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+           return self;
+         },
+         "DEPRECATED: The addition assignment operator += is deprecated in"
+         " favor of the multiplication assignment operator *=, though the"
+         " order of operands is reversed (A + B = B * A). See Migration.md .",
+         py::is_operator())
+    .def("__neg__",
+         [](Class &self)
+         {
+           PyErr_WarnEx(
+             PyExc_DeprecationWarning,
+             "The unitary negation operator - is deprecated in favor"
+             " of the inverse operator. See Migration.md .",
+             1);
+           GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+           return -self;
+           GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+         },
+         "DEPRECATED: The unitary negation operator - is deprecated in favor"
+         " of the inverse operator. See Migration.md .",
+         py::is_operator())
+    .def("__sub__",
+         [](const Class &self, const gz::math::Pose3<T> &other)
+         {
+           PyErr_WarnEx(
+             PyExc_DeprecationWarning,
+             "The subtraction operator - is deprecated in favor of"
+             " multiplication by the inverse, though the order of operands is"
+             " reversed (A - B = B.inverse() * A). See Migration.md .",
+             1);
+           GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+           return self - other;
+           GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+         },
+         "DEPRECATED: The subtraction operator - is deprecated in favor of"
+         " multiplication by the inverse, though the order of operands is"
+         " reversed (A - B = B.inverse() * A). See Migration.md .",
+         py::is_operator())
+    .def("__isub__",
+         [](Class &self, const gz::math::Pose3<T> &other)
+         {
+           PyErr_WarnEx(
+             PyExc_DeprecationWarning,
+             "The subtraction assignment operator -= is deprecated in favor"
+             " of multiplication by the inverse, though the order of operands"
+             " is reversed (A - B = B.inverse() * A). See Migration.md .",
+             1);
+           GZ_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+           self -= other;
+           GZ_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+           return self;
+         },
+         "DEPRECATED: The subtraction assignment operator -= is deprecated in"
+         " favor of multiplication by the inverse, though the order of operands"
+         " is reversed (A - B = B.inverse() * A). See Migration.md .",
+         py::is_operator())
     .def(py::self == py::self)
     .def(py::self != py::self)
     .def(py::self * py::self)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation warnings on macOS, part of https://github.com/gazebosim/gz-math/issues/60.

## Summary

Several deprecated operators of the Pose3 class (see https://github.com/gazebosim/gz-math/issues/60) are causing compilation warnings in our python bindings. This uses a more verbose way of specifying these operator bindings, while adding a console warning message, and suppressing the compiler warnings.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
