### PR TITLE
packages.apt: use jetty package names

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,6 +1,6 @@
+gz-jetty-cmake
+gz-jetty-utils
 libeigen3-dev
-libgz-cmake5-dev
-libgz-utils4-dev
 libpython3-dev
 python3-numpy
 python3-pybind11


### PR DESCRIPTION
# 🎉 New feature

Prototype for https://github.com/gazebo-tooling/release-tools/issues/1326.

## Summary

Use unversioned `gz-jetty-*` package names in packages.apt file.

## Test it

Verify that CI passes

Requires:

* https://github.com/gazebo-release/gz-cmake5-release/pull/3
* https://github.com/gazebo-release/gz-utils4-release/pull/6

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
