### PR TITLE
Replace main with gz-math9

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,9 +1,9 @@
 name: Bazel CI
 on:
   push:
-    branches: [gz-math8, main]
+    branches: [gz-math8, gz-math9, main]
   pull_request:
-    branches: [gz-math8, main]
+    branches: [gz-math8, gz-math9, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build | Status
 Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-math/branch/gz-math9/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-math/tree/gz-math9)
 Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-gz-math9-noble-amd64)](https://build.osrfoundation.org/job/gz_math-ci-gz-math9-noble-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-gz-math9-homebrew-amd64)](https://build.osrfoundation.org/job/gz_math-ci-gz-math9-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-9-clowin)](https://build.osrfoundation.org/job/gz_math-9-clowin)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-9-cnlwin)](https://build.osrfoundation.org/job/gz_math-9-cnlwin)
 
 Gazebo Math, a component of [Gazebo](https://gazebosim.org), provides general purpose math
 classes and functions designed for robotic applications.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-math/branch/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-math/tree/main)
-Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-main-noble-amd64)](https://build.osrfoundation.org/job/gz_math-ci-main-noble-amd64)
-Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/gz_math-ci-main-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-main-clowin)](https://build.osrfoundation.org/job/gz_math-main-clowin)
+Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-math/branch/gz-math9/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-math/tree/gz-math9)
+Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-gz-math9-noble-amd64)](https://build.osrfoundation.org/job/gz_math-ci-gz-math9-noble-amd64)
+Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-gz-math9-homebrew-amd64)](https://build.osrfoundation.org/job/gz_math-ci-gz-math9-homebrew-amd64)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-9-clowin)](https://build.osrfoundation.org/job/gz_math-9-clowin)
 
 Gazebo Math, a component of [Gazebo](https://gazebosim.org), provides general purpose math
 classes and functions designed for robotic applications.
@@ -51,7 +51,7 @@ See the [installation tutorial](https://gazebosim.org/api/math/8/install.html).
 
 # Usage
 
-Please refer to the [examples directory](https://github.com/gazebosim/gz-math/raw/main/examples/).
+Please refer to the [examples directory](https://github.com/gazebosim/gz-math/raw/gz-math9/examples/).
 
 # Folder Structure
 
@@ -82,7 +82,7 @@ Please see the
 # Code of Conduct
 
 Please see
-[CODE_OF_CONDUCT.md](https://github.com/gazebosim/gz-sim/blob/main/CODE_OF_CONDUCT.md).
+[CODE_OF_CONDUCT.md](https://github.com/gazebosim/gz-sim/blob/gz-math9/CODE_OF_CONDUCT.md).
 
 # Versioning
 
@@ -90,4 +90,4 @@ This library uses [Semantic Versioning](https://semver.org/). Additionally, this
 
 # License
 
-This library is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). See also the [LICENSE](https://github.com/gazebosim/gz-math/blob/main/LICENSE) file.
+This library is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). See also the [LICENSE](https://github.com/gazebosim/gz-math/blob/gz-math9/LICENSE) file.

--- a/tutorials/color.md
+++ b/tutorials/color.md
@@ -7,7 +7,7 @@ This tutorial explains how to use the `Color` class from Gazebo Math library.
 Go to `gz-math/examples` and use `cmake` to compile the code:
 
 ```{.sh}
-git clone https://github.com/gazebosim/gz-math/ -b main
+git clone https://github.com/gazebosim/gz-math/ -b gz-math9
 cd gz-math/examples
 mkdir build
 cd build


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-jetty/issues/22.

## Summary

Replace references to `main` branch with `gz-math9` and enable bazel CI on gz-math9.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
