### PR TITLE
Removed warning OccupancyGrid

### DIFF
--- a/src/OccupancyGrid.cc
+++ b/src/OccupancyGrid.cc
@@ -29,6 +29,7 @@ using namespace math;
 // Private implementation struct/class
 class OccupancyGrid::Implementation
 {
+public:
   double resolutionMeters;
   int widthCells;
   int heightCells;

--- a/src/OccupancyGrid.cc
+++ b/src/OccupancyGrid.cc
@@ -27,7 +27,7 @@ using namespace math;
 
 /////////////////////////////////////////////////
 // Private implementation struct/class
-struct OccupancyGrid::Implementation
+class OccupancyGrid::Implementation
 {
   double resolutionMeters;
   int widthCells;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Related with this warning https://ci.ros2.org/view/nightly/job/nightly_win_rep/3858/msbuild/fileName.-1682520037/

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
