### PR TITLE
Add VolumeBelow/CenterOfVolumeBelow for Ellipsoid, Cylinder, Capsule (backport #730)

### DIFF
--- a/include/gz/math/Capsule.hh
+++ b/include/gz/math/Capsule.hh
@@ -20,6 +20,7 @@
 #include <optional>
 #include "gz/math/MassMatrix3.hh"
 #include "gz/math/Material.hh"
+#include "gz/math/Plane.hh"
 
 namespace ignition
 {
@@ -97,6 +98,23 @@ namespace ignition
       /// \brief Get the volume of the capsule in m^3.
       /// \return Volume of the capsule in m^3.
       public: Precision Volume() const;
+
+      /// \brief Get the volume of the capsule below a given plane in m^3.
+      /// It is assumed that the center of the capsule is on the origin.
+      /// \param[in] _plane The plane which slices this capsule, expressed
+      /// in the capsule's reference frame.
+      /// \return Volume below the plane in m^3.
+      public: Precision VolumeBelow(const Plane<Precision> &_plane) const;
+
+      /// \brief Center of volume below the plane. This is useful for example
+      /// when calculating where buoyancy should be applied.
+      /// \param[in] _plane The plane which slices this capsule, expressed
+      /// in the capsule's reference frame.
+      /// \return The center of volume if there is anything below the plane,
+      /// otherwise return a std::nullopt. Expressed in the capsule's
+      /// reference frame.
+      public: std::optional<Vector3<Precision>>
+        CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Compute the capsule's density given a mass value. The
       /// capsule is assumed to be solid with uniform density. This

--- a/include/gz/math/Cylinder.hh
+++ b/include/gz/math/Cylinder.hh
@@ -17,8 +17,10 @@
 #ifndef GZ_MATH_CYLINDER_HH_
 #define GZ_MATH_CYLINDER_HH_
 
+#include <optional>
 #include "gz/math/MassMatrix3.hh"
 #include "gz/math/Material.hh"
+#include "gz/math/Plane.hh"
 #include "gz/math/Quaternion.hh"
 
 namespace ignition
@@ -125,6 +127,23 @@ namespace ignition
       /// \brief Get the volume of the cylinder in m^3.
       /// \return Volume of the cylinder in m^3.
       public: Precision Volume() const;
+
+      /// \brief Get the volume of the cylinder below a given plane in m^3.
+      /// It is assumed that the center of the cylinder is on the origin.
+      /// \param[in] _plane The plane which slices this cylinder, expressed
+      /// in the cylinder's reference frame.
+      /// \return Volume below the plane in m^3.
+      public: Precision VolumeBelow(const Plane<Precision> &_plane) const;
+
+      /// \brief Center of volume below the plane. This is useful for example
+      /// when calculating where buoyancy should be applied.
+      /// \param[in] _plane The plane which slices this cylinder, expressed
+      /// in the cylinder's reference frame.
+      /// \return The center of volume if there is anything below the plane,
+      /// otherwise return a std::nullopt. Expressed in the cylinder's
+      /// reference frame.
+      public: std::optional<Vector3<Precision>>
+        CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Compute the cylinder's density given a mass value. The
       /// cylinder is assumed to be solid with uniform density. This

--- a/include/gz/math/Ellipsoid.hh
+++ b/include/gz/math/Ellipsoid.hh
@@ -20,6 +20,7 @@
 #include <optional>
 #include "gz/math/MassMatrix3.hh"
 #include "gz/math/Material.hh"
+#include "gz/math/Plane.hh"
 
 namespace ignition
 {
@@ -83,6 +84,23 @@ namespace ignition
       /// \brief Get the volume of the ellipsoid in m^3.
       /// \return Volume of the ellipsoid in m^3.
       public: Precision Volume() const;
+
+      /// \brief Get the volume of ellipsoid below a given plane in m^3.
+      /// It is assumed that the center of the ellipsoid is on the origin.
+      /// \param[in] _plane The plane which slices this ellipsoid, expressed
+      /// in the ellipsoid's reference frame.
+      /// \return Volume below the plane in m^3.
+      public: Precision VolumeBelow(const Plane<Precision> &_plane) const;
+
+      /// \brief Center of volume below the plane. This is useful for example
+      /// when calculating where buoyancy should be applied.
+      /// \param[in] _plane The plane which slices this ellipsoid, expressed
+      /// in the ellipsoid's reference frame.
+      /// \return The center of volume if there is anything below the plane,
+      /// otherwise return a std::nullopt. Expressed in the ellipsoid's
+      /// reference frame.
+      public: std::optional<Vector3<Precision>>
+        CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
       /// \brief Compute the ellipsoid's density given a mass value. The
       /// ellipsoid is assumed to be solid with uniform density. This

--- a/include/gz/math/detail/Capsule.hh
+++ b/include/gz/math/detail/Capsule.hh
@@ -17,10 +17,15 @@
 #ifndef GZ_MATH_DETAIL_CAPSULE_HH_
 #define GZ_MATH_DETAIL_CAPSULE_HH_
 
+#include <algorithm>
+#include <cmath>
 #include <limits>
 #include <optional>
+#include <gz/math/Capsule.hh>
+#include <gz/math/Cylinder.hh>
 #include <gz/math/Helpers.hh>
 #include <gz/math/Inertial.hh>
+#include <gz/math/Sphere.hh>
 
 namespace ignition
 {
@@ -137,6 +142,161 @@ T Capsule<T>::Volume() const
 {
   return IGN_PI * std::pow(this->radius, 2) *
          (this->length + 4. / 3. * this->radius);
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Capsule<T>::VolumeBelow(const Plane<T> &_plane) const
+{
+  auto r = this->radius;
+  auto halfLen = this->length / 2;
+
+  if (r <= 0 || this->length <= 0)
+    return 0;
+
+  // Decompose into: bottom hemisphere at z = -halfLen,
+  // cylinder from -halfLen to +halfLen, top hemisphere at z = +halfLen.
+  // Translate the plane to each sub-shape's local frame.
+
+  auto n = _plane.Normal();
+  auto d = _plane.Offset();
+
+  // Decompose into cylinder middle + bottom hemisphere + top hemisphere.
+  // For a sub-shape centered at (0,0,zOff), the plane in its local
+  // frame has the same normal but offset d' = d - n.Z()*zOff.
+
+  Sphere<T> sphere(r);
+  Cylinder<T> cyl(this->length, r);
+  T vCyl = cyl.VolumeBelow(_plane);
+
+  T halfSphereVol = sphere.Volume() / 2;
+
+  // Bottom hemisphere: center at (0,0,-halfLen), hemisphere is z <= 0 local.
+  // Translate plane to sphere's local frame.
+  Plane<T> planeBot(n, d + n.Z() * halfLen);
+  T vSphereBot = sphere.VolumeBelow(planeBot);
+  // The hemisphere is {z <= 0}. The sphere volume below cutting plane
+  // that lies within this hemisphere is min(vSphereBot, halfSphereVol).
+  T vBot = std::min(vSphereBot, halfSphereVol);
+
+  // Top hemisphere: center at (0,0,+halfLen), hemisphere is z >= 0 local.
+  Plane<T> planeTop(n, d - n.Z() * halfLen);
+  T vSphereTop = sphere.VolumeBelow(planeTop);
+  // Volume in top hemisphere = volume below plane minus bottom hemisphere
+  T vTop = std::max(static_cast<T>(0), vSphereTop - halfSphereVol);
+
+  return vCyl + vBot + vTop;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+std::optional<Vector3<T>>
+ Capsule<T>::CenterOfVolumeBelow(const Plane<T> &_plane) const
+{
+  auto r = this->radius;
+  auto halfLen = this->length / 2;
+
+  if (r <= 0 || this->length <= 0)
+    return std::nullopt;
+
+  auto n = _plane.Normal();
+  auto d = _plane.Offset();
+
+  Sphere<T> sphere(r);
+  Cylinder<T> cyl(this->length, r);
+  T halfSphereVol = sphere.Volume() / 2;
+
+  // Cylinder contribution
+  T vCyl = cyl.VolumeBelow(_plane);
+  auto covCyl = cyl.CenterOfVolumeBelow(_plane);
+
+  // Bottom hemisphere: center at (0,0,-halfLen)
+  Plane<T> planeBot(n, d + n.Z() * halfLen);
+  T vSphereBot = sphere.VolumeBelow(planeBot);
+  T vBot = std::min(vSphereBot, halfSphereVol);
+
+  // Top hemisphere: center at (0,0,+halfLen)
+  Plane<T> planeTop(n, d - n.Z() * halfLen);
+  T vSphereTop = sphere.VolumeBelow(planeTop);
+  T vTop = std::max(static_cast<T>(0), vSphereTop - halfSphereVol);
+
+  T totalVol = vCyl + vBot + vTop;
+  if (totalVol <= 0)
+    return std::nullopt;
+
+  Vector3<T> moment(0, 0, 0);
+
+  // Cylinder moment
+  if (covCyl.has_value())
+    moment += (*covCyl) * vCyl;
+
+  // Bottom hemisphere moment
+  // We need the centroid of {sphere below cutting plane} intersect {z <= 0}
+  // in the sphere's local frame, then shift by (0,0,-halfLen).
+  if (vBot > 0)
+  {
+    Vector3<T> botCenter(0, 0, -halfLen);
+    if (vBot < 1e-12 * totalVol)
+    {
+      // Tiny slice: approximate centroid at hemisphere center to avoid
+      // catastrophic cancellation.
+      moment += botCenter * vBot;
+    }
+    else if (vBot >= halfSphereVol - 1e-15 * sphere.Volume())
+    {
+      // Entire hemisphere is below cutting plane
+      // Centroid of hemisphere (z <= 0) of sphere of radius r is at
+      // z = -3r/8
+      moment += (botCenter + Vector3<T>(0, 0, -3 * r / 8)) * vBot;
+    }
+    else
+    {
+      // Cutting plane intersects the hemisphere below the equator.
+      // The entire sphere volume below the cutting plane is within
+      // the hemisphere (vSphereBot <= halfSphereVol).
+      auto covSphBot = sphere.CenterOfVolumeBelow(planeBot);
+      if (covSphBot.has_value())
+        moment += (botCenter + *covSphBot) * vBot;
+    }
+  }
+
+  // Top hemisphere moment
+  if (vTop > 0)
+  {
+    Vector3<T> topCenter(0, 0, halfLen);
+    if (vTop < 1e-12 * totalVol)
+    {
+      // Tiny slice: approximate centroid at hemisphere center to avoid
+      // catastrophic cancellation in the subtraction formula.
+      moment += topCenter * vTop;
+    }
+    else if (vTop >= halfSphereVol - 1e-15 * sphere.Volume())
+    {
+      // Entire top hemisphere is below cutting plane
+      // Centroid of hemisphere (z >= 0) at z = +3r/8
+      moment += (topCenter + Vector3<T>(0, 0, 3 * r / 8)) * vTop;
+    }
+    else
+    {
+      // Cutting plane intersects the top hemisphere.
+      // Volume above equator and below cutting plane:
+      // vTop = vSphereTop - halfSphereVol
+      // This is the "annular" cap between the equator and the cutting plane.
+      // Centroid = (vSphereTop * covSphTop - halfSphereVol * covEquator)
+      //            / vTop
+      auto covSphTop = sphere.CenterOfVolumeBelow(planeTop);
+      // Centroid of bottom hemisphere (below equator) is at (0,0,-3r/8)
+      Vector3<T> covEquator(0, 0, -3 * r / 8);
+      if (covSphTop.has_value())
+      {
+        auto annularMoment = (*covSphTop) * vSphereTop
+                           - covEquator * halfSphereVol;
+        moment += (topCenter * vTop + annularMoment);
+      }
+    }
+  }
+
+  return moment / totalVol;
 }
 
 //////////////////////////////////////////////////

--- a/include/gz/math/detail/Cylinder.hh
+++ b/include/gz/math/detail/Cylinder.hh
@@ -16,6 +16,13 @@
 */
 #ifndef GZ_MATH_DETAIL_CYLINDER_HH_
 #define GZ_MATH_DETAIL_CYLINDER_HH_
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+#include "gz/math/Cylinder.hh"
+#include "gz/math/detail/WetVolume.hh"
+
 namespace ignition
 {
 namespace math
@@ -122,6 +129,200 @@ T Cylinder<T>::Volume() const
 {
   return IGN_PI * std::pow(this->radius, 2) *
          this->length;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Cylinder<T>::VolumeBelow(const Plane<T> &_plane) const
+{
+  auto r = this->radius;
+  auto halfLen = this->length / 2;
+
+  if (r <= 0 || this->length <= 0)
+    return 0;
+
+  // Transform plane to Z-aligned cylinder frame
+  auto localNormal =
+    this->rotOffset.RotateVectorReverse(_plane.Normal());
+  auto d = _plane.Offset();
+  auto nx = localNormal.X();
+  auto ny = localNormal.Y();
+  auto nz = localNormal.Z();
+  auto nxy = std::sqrt(nx * nx + ny * ny);
+  auto fullArea = IGN_PI * r * r;
+
+  // Horizontal plane (no radial component)
+  if (nxy < 1e-15 * (std::abs(nz) + 1e-30))
+  {
+    if (std::abs(nz) < 1e-30)
+      return (d >= 0) ? this->Volume() : 0;
+    auto zCut = d / nz;
+    auto h = std::max(static_cast<T>(0),
+                      std::min(this->length, zCut + halfLen));
+    return fullArea * h;
+  }
+
+  // Vertical plane (no axial component)
+  if (std::abs(nz) < 1e-15 * nxy)
+  {
+    auto p = d / nxy;
+    T area;
+    if (p >= r) area = fullArea;
+    else if (p <= -r) area = 0;
+    else area = detail::circSegArea(p, r);
+    return area * this->length;
+  }
+
+  // General case: both nxy > 0 and nz != 0
+  // p(z) = (d - nz*z) / nxy at each height z
+  auto p1 = (d + nz * halfLen) / nxy;  // p at z = -halfLen
+  auto p2 = (d - nz * halfLen) / nxy;  // p at z = +halfLen
+  auto pLo = std::min(p1, p2);
+  auto pHi = std::max(p1, p2);
+  auto dzDp = nxy / std::abs(nz);
+
+  T vol = 0;
+
+  // Full-circle region: p > r
+  if (pHi > r)
+    vol += fullArea * (pHi - std::max(pLo, r)) * dzDp;
+
+  // Partial region: -r <= p <= r
+  auto pLoC = std::max(pLo, -r);
+  auto pHiC = std::min(pHi, r);
+  if (pLoC < pHiC)
+    vol += (detail::circSegAreaAntideriv(pHiC, r)
+          - detail::circSegAreaAntideriv(pLoC, r)) * dzDp;
+
+  return vol;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+std::optional<Vector3<T>>
+ Cylinder<T>::CenterOfVolumeBelow(const Plane<T> &_plane) const
+{
+  auto r = this->radius;
+  auto halfLen = this->length / 2;
+
+  if (r <= 0 || this->length <= 0)
+    return std::nullopt;
+
+  auto localNormal =
+    this->rotOffset.RotateVectorReverse(_plane.Normal());
+  auto d = _plane.Offset();
+  auto nx = localNormal.X();
+  auto ny = localNormal.Y();
+  auto nz = localNormal.Z();
+  auto nxy = std::sqrt(nx * nx + ny * ny);
+  auto fullArea = IGN_PI * r * r;
+
+  // Horizontal plane
+  if (nxy < 1e-15 * (std::abs(nz) + 1e-30))
+  {
+    if (std::abs(nz) < 1e-30)
+    {
+      return (d >= 0) ? std::optional(Vector3<T>{0, 0, 0}) : std::nullopt;
+    }
+    auto zCut = d / nz;
+    auto zLo = -halfLen;
+    auto h = std::max(static_cast<T>(0),
+                      std::min(this->length, zCut + halfLen));
+    if (h <= 0) return std::nullopt;
+    auto zTop = zLo + h;
+    auto cz = (zLo + zTop) / 2;
+    return this->rotOffset.RotateVector(Vector3<T>(0, 0, cz));
+  }
+
+  // Vertical plane
+  if (std::abs(nz) < 1e-15 * nxy)
+  {
+    auto p = d / nxy;
+    T area;
+    if (p >= r) area = fullArea;
+    else if (p <= -r) area = 0;
+    else area = detail::circSegArea(p, r);
+
+    if (area <= 0)
+      return std::nullopt;
+
+    // Centroid z = 0 by symmetry.
+    // Centroid in 2D normal direction:
+    // m_perp = -(2/3)*(R^2-p^2)^(3/2) for |p| < R, else 0
+    T cx = 0, cy = 0;
+    if (std::abs(p) < r)
+    {
+      auto diff = r * r - p * p;
+      auto mPerp = -(static_cast<T>(2) / 3) * diff * std::sqrt(diff);
+      cx = (nx / nxy) * mPerp / area;
+      cy = (ny / nxy) * mPerp / area;
+    }
+    return this->rotOffset.RotateVector(Vector3<T>(cx, cy, 0));
+  }
+
+  // General case
+  auto p1 = (d + nz * halfLen) / nxy;
+  auto p2 = (d - nz * halfLen) / nxy;
+  auto pLo = std::min(p1, p2);
+  auto pHi = std::max(p1, p2);
+  auto dzDp = nxy / std::abs(nz);
+
+  T vol = 0;
+
+  // Volume computation (same as VolumeBelow)
+  if (pHi > r)
+    vol += fullArea * (pHi - std::max(pLo, r)) * dzDp;
+  auto pLoC = std::max(pLo, -r);
+  auto pHiC = std::min(pHi, r);
+  if (pLoC < pHiC)
+    vol += (detail::circSegAreaAntideriv(pHiC, r)
+          - detail::circSegAreaAntideriv(pLoC, r)) * dzDp;
+
+  if (vol <= 0)
+    return std::nullopt;
+
+  // Z-moment: Mz = (nxy/(|nz|*nz)) * integral of (d-nxy*p)*A(p) dp
+  // = (nxy/(|nz|*nz)) * [d*F(p) - nxy*H(p)] evaluated over regions
+  T zMomIntegral = 0;
+
+  // Full-circle region: p > r -> A = pi*r^2
+  // integral of (d - nxy*p) * pi*r^2 dp
+  // = pi*r^2 * [d*p - nxy*p^2/2]
+  if (pHi > r)
+  {
+    auto pFullLo = std::max(pLo, r);
+    zMomIntegral += fullArea * (d * (pHi - pFullLo)
+      - nxy * (pHi * pHi - pFullLo * pFullLo) / 2);
+  }
+
+  // Partial region: -r <= p <= r
+  if (pLoC < pHiC)
+  {
+    zMomIntegral +=
+      d * (detail::circSegAreaAntideriv(pHiC, r)
+         - detail::circSegAreaAntideriv(pLoC, r))
+    - nxy * (detail::circSegPAntideriv(pHiC, r)
+           - detail::circSegPAntideriv(pLoC, r));
+  }
+
+  auto Mz = (nxy / (std::abs(nz) * nz)) * zMomIntegral;
+
+  // XY-moments via perpendicular first moment of circular segment
+  // m_perp(p) = -(2/3)*(R^2-p^2)^(3/2) for |p| < R, else 0
+  // Mx = -(2*nx)/(3*|nz|) * [J(pHiC) - J(pLoC)]
+  // My = -(2*ny)/(3*|nz|) * [J(pHiC) - J(pLoC)]
+  T Mx = 0, My = 0;
+  if (pLoC < pHiC)
+  {
+    auto dJ = detail::r2p2_32_Antideriv(pHiC, r)
+            - detail::r2p2_32_Antideriv(pLoC, r);
+    auto coeff = static_cast<T>(-2) / (3 * std::abs(nz));
+    Mx = nx * coeff * dJ;
+    My = ny * coeff * dJ;
+  }
+
+  auto centroid = Vector3<T>(Mx / vol, My / vol, Mz / vol);
+  return this->rotOffset.RotateVector(centroid);
 }
 
 //////////////////////////////////////////////////

--- a/include/gz/math/detail/Ellipsoid.hh
+++ b/include/gz/math/detail/Ellipsoid.hh
@@ -17,8 +17,10 @@
 #ifndef GZ_MATH_DETAIL_ELLIPSOID_HH_
 #define GZ_MATH_DETAIL_ELLIPSOID_HH_
 
+#include <cmath>
 #include <limits>
 #include <optional>
+#include "gz/math/Ellipsoid.hh"
 #include <gz/math/Helpers.hh>
 #include <gz/math/Inertial.hh>
 
@@ -96,8 +98,97 @@ std::optional< MassMatrix3<T> > Ellipsoid<T>::MassMatrix() const
 template<typename T>
 T Ellipsoid<T>::Volume() const
 {
-  const T kFourThirdsPi = 4. * IGN_PI / 3.;
+  const T kFourThirdsPi = static_cast<T>(4. * IGN_PI / 3.);
   return kFourThirdsPi * this->radii.X() * this->radii.Y() * this->radii.Z();
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+T Ellipsoid<T>::VolumeBelow(const Plane<T> &_plane) const
+{
+  auto a = this->radii.X();
+  auto b = this->radii.Y();
+  auto c = this->radii.Z();
+
+  if (a <= 0 || b <= 0 || c <= 0)
+    return 0;
+
+  // Transform plane into unit sphere space via affine map (x/a, y/b, z/c).
+  // Transformed plane normal: n' = (n_x*a, n_y*b, n_z*c)
+  // Transformed plane offset: unchanged (d)
+  auto n = _plane.Normal();
+  Vector3<T> nt(n.X() * a, n.Y() * b, n.Z() * c);
+  auto ntLen = nt.Length();
+
+  if (ntLen < 1e-15)
+    return 0;
+
+  // Signed distance from unit sphere center to transformed plane
+  auto signedDist = -_plane.Offset() / ntLen;
+
+  if (signedDist < -1)
+  {
+    // Entire ellipsoid is below the plane
+    return this->Volume();
+  }
+  else if (signedDist > 1)
+  {
+    // Entire ellipsoid is above the plane
+    return 0;
+  }
+
+  // Spherical cap on unit sphere: h = 1 - signedDist
+  auto h = 1 - signedDist;
+  auto capVol = IGN_PI * h * h * (3 - h) / 3;
+
+  // Scale by ellipsoid volume ratio: abc
+  return a * b * c * capVol;
+}
+
+//////////////////////////////////////////////////
+template<typename T>
+std::optional<Vector3<T>>
+ Ellipsoid<T>::CenterOfVolumeBelow(const Plane<T> &_plane) const
+{
+  auto a = this->radii.X();
+  auto b = this->radii.Y();
+  auto c = this->radii.Z();
+
+  if (a <= 0 || b <= 0 || c <= 0)
+    return std::nullopt;
+
+  auto n = _plane.Normal();
+  Vector3<T> nt(n.X() * a, n.Y() * b, n.Z() * c);
+  auto ntLen = nt.Length();
+
+  if (ntLen < 1e-15)
+    return std::nullopt;
+
+  auto signedDist = -_plane.Offset() / ntLen;
+
+  if (signedDist < -1)
+  {
+    // Entire ellipsoid is below the plane
+    return Vector3<T>{0, 0, 0};
+  }
+  else if (signedDist > 1)
+  {
+    // Entire ellipsoid is above the plane
+    return std::nullopt;
+  }
+
+  // Spherical cap centroid distance from sphere center (unit sphere, r=1)
+  auto h = 1 - signedDist;
+  auto numerator = 2 - h;
+  auto zBar = 3 * numerator * numerator / (4 * (3 - h));
+
+  // Centroid in unit sphere space is at -zBar * (nt / ntLen)
+  // Transform back to ellipsoid space: multiply each component by its
+  // semi-axis. Result: -zBar / ntLen * (a^2*n_x, b^2*n_y, c^2*n_z)
+  auto scale = -zBar / ntLen;
+  return Vector3<T>(scale * a * a * n.X(),
+                    scale * b * b * n.Y(),
+                    scale * c * c * n.Z());
 }
 
 //////////////////////////////////////////////////

--- a/include/gz/math/detail/WetVolume.hh
+++ b/include/gz/math/detail/WetVolume.hh
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/// \file WetVolume.hh
+/// \brief Helpers for computing the volume and centroid of the portion
+/// of a solid of revolution that lies below an arbitrary cutting plane
+/// ("wet volume"), used by VolumeBelow / CenterOfVolumeBelow on
+/// Cylinder, Capsule, and Ellipsoid.
+///
+/// Two families of helpers are provided:
+///
+/// **Circular-segment primitives** -- closed-form area and moment
+/// integrals for the region of a circle of radius R that lies on one
+/// side of a chord at signed distance p from the center.  The area
+/// formula is classical geometry (see Weisstein, "Circular Segment",
+/// MathWorld, https://mathworld.wolfram.com/CircularSegment.html).
+/// The antiderivatives (F, H, J) are obtained by integration by parts
+/// and are used by the Cylinder implementation to evaluate the swept
+/// volume and centroid in closed form via Cavalieri's principle.
+///
+/// **Gauss-Legendre 10-point quadrature** -- numerical integration for
+/// integrands that do not admit a closed-form antiderivative.  Nodes and
+/// weights are the standard GL-10 values (Abramowitz & Stegun,
+/// Table 25.4; DLMF 3.5, https://dlmf.nist.gov/3.5).
+#ifndef GZ_MATH_DETAIL_WET_VOLUME_HH_
+#define GZ_MATH_DETAIL_WET_VOLUME_HH_
+
+#include <cmath>
+#include <gz/math/config.hh>
+
+namespace ignition
+{
+namespace math
+{
+inline namespace IGNITION_MATH_VERSION_NAMESPACE {
+namespace detail
+{
+  /// \brief Area of a circular segment for a circle of radius R at
+  /// signed distance p from the center.  Valid for |p| <= R.
+  /// A(p) = R^2 * arccos(-p/R) + p * sqrt(R^2 - p^2)
+  /// \ref https://mathworld.wolfram.com/CircularSegment.html
+  template<typename T>
+  T circSegArea(T p, T R)
+  {
+    auto R2 = R * R;
+    auto diff = R2 - p * p;
+    return R2 * std::acos(-p / R) + p * std::sqrt(diff);
+  }
+
+  /// \brief Antiderivative of circSegArea(p, R) w.r.t. p (|p| <= R).
+  /// Used by Cylinder::VolumeBelow to integrate the swept segment area
+  /// along the cylinder axis in closed form.
+  /// F(p) = R^2*p*arccos(-p/R) + R^2*sqrt(R^2-p^2) - (R^2-p^2)^(3/2)/3
+  /// F(-R) = 0, F(R) = pi*R^3.
+  template<typename T>
+  T circSegAreaAntideriv(T p, T R)
+  {
+    auto R2 = R * R;
+    auto diff = R2 - p * p;
+    auto sd = std::sqrt(diff);
+    return R2 * p * std::acos(-p / R) + R2 * sd - diff * sd / 3;
+  }
+
+  /// \brief Antiderivative of p*circSegArea(p, R) w.r.t. p (|p| <= R).
+  /// Used by Cylinder::CenterOfVolumeBelow for the z-moment integral.
+  /// H(p) = R^2*(4p^2-R^2)/8 * arccos(-p/R) + p*(R^2+2p^2)/8 * sqrt(R^2-p^2)
+  /// H(-R) = 0, H(R) = 3*pi*R^4/8.
+  template<typename T>
+  T circSegPAntideriv(T p, T R)
+  {
+    auto R2 = R * R;
+    auto p2 = p * p;
+    auto sd = std::sqrt(R2 - p2);
+    return R2 * (4 * p2 - R2) / 8 * std::acos(-p / R)
+         + p * (R2 + 2 * p2) / 8 * sd;
+  }
+
+  /// \brief Antiderivative of (R^2 - p^2)^(3/2) w.r.t. p (|p| <= R).
+  /// Used by Cylinder::CenterOfVolumeBelow for the perpendicular (x,y)
+  /// moment integral, derived from the first moment of a circular
+  /// segment: m_perp(p) = -(2/3)(R^2 - p^2)^(3/2).
+  /// J(p) = p*(5R^2-2p^2)*sqrt(R^2-p^2)/8 + 3R^4*arcsin(p/R)/8
+  template<typename T>
+  T r2p2_32_Antideriv(T p, T R)
+  {
+    auto R2 = R * R;
+    auto p2 = p * p;
+    auto sd = std::sqrt(R2 - p2);
+    return p * (5 * R2 - 2 * p2) * sd / 8
+         + 3 * R2 * R2 * std::asin(p / R) / 8;
+  }
+
+  /// \brief 10-point Gauss-Legendre nodes on [-1, 1].
+  /// \ref Abramowitz & Stegun, Table 25.4; DLMF 3.5
+  /// (https://dlmf.nist.gov/3.5)
+  constexpr double gl10Nodes[10] = {
+    -0.97390652851717172, -0.86506336668898451,
+    -0.67940956829902441, -0.43339539412924719,
+    -0.14887433898163122,  0.14887433898163122,
+     0.43339539412924719,  0.67940956829902441,
+     0.86506336668898451,  0.97390652851717172
+  };
+
+  /// \brief 10-point Gauss-Legendre weights on [-1, 1].
+  constexpr double gl10Weights[10] = {
+    0.06667134430868814, 0.14945134915058060,
+    0.21908636251598204, 0.26926671930999636,
+    0.29552422471475287, 0.29552422471475287,
+    0.26926671930999636, 0.21908636251598204,
+    0.14945134915058060, 0.06667134430868814
+  };
+
+  /// \brief Integrate a function f over [a, b] using 10-point
+  /// Gauss-Legendre quadrature.  Exact for polynomials up to degree 19.
+  template<typename T, typename Func>
+  T glIntegrate(Func f, T a, T b)
+  {
+    auto mid = (a + b) / 2;
+    auto halfW = (b - a) / 2;
+    T sum = 0;
+    for (int i = 0; i < 10; ++i)
+      sum += static_cast<T>(gl10Weights[i])
+           * f(mid + halfW * static_cast<T>(gl10Nodes[i]));
+    return sum * halfW;
+  }
+}  // namespace detail
+}  // namespace IGNITION_MATH_VERSION_NAMESPACE
+}  // namespace math
+}  // namespace ignition
+
+#endif  // GZ_MATH_DETAIL_WET_VOLUME_HH_

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -128,3 +128,40 @@ TEST(CapsuleTest, Mass)
   EXPECT_EQ(expectedMassMat.DiagonalMoments(), massMat->DiagonalMoments());
   EXPECT_DOUBLE_EQ(expectedMassMat.Mass(), massMat->Mass());
 }
+
+/////////////////////////////////////////////////
+TEST(CapsuleTest, VolumeBelowFloat)
+{
+  float length = 2.0f;
+  float r = 1.0f;
+  math::Capsule<float> cap(length, r);
+
+  // Horizontal plane at z=0: half volume by symmetry
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 0.0f);
+    EXPECT_NEAR(cap.Volume() / 2.0f, cap.VolumeBelow(plane), 1e-3f);
+  }
+
+  // Fully below
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 10.0f);
+    EXPECT_NEAR(cap.Volume(), cap.VolumeBelow(plane), 1e-3f);
+  }
+
+  // Fully above
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, -10.0f);
+    EXPECT_NEAR(0.0f, cap.VolumeBelow(plane), 1e-3f);
+  }
+
+  // CenterOfVolumeBelow with float
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 0.0f);
+    auto cov = cap.CenterOfVolumeBelow(plane);
+    ASSERT_TRUE(cov.has_value());
+    EXPECT_NEAR(0.0f, cov.value().X(), 1e-3f);
+    EXPECT_NEAR(0.0f, cov.value().Y(), 1e-3f);
+    // Bottom half centroid is below z=0
+    EXPECT_TRUE(cov.value().Z() < 0.0f);
+  }
+}

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -138,3 +138,39 @@ TEST(CylinderTest, Mass)
   EXPECT_EQ(expectedMassMat, massMat);
   EXPECT_DOUBLE_EQ(expectedMassMat.Mass(), massMat.Mass());
 }
+
+/////////////////////////////////////////////////
+TEST(CylinderTest, VolumeBelowFloat)
+{
+  float length = 4.0f;
+  float r = 2.0f;
+  math::Cylinder<float> cyl(length, r);
+
+  // Horizontal plane at z=0: half volume
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 0.0f);
+    EXPECT_NEAR(cyl.Volume() / 2.0f, cyl.VolumeBelow(plane), 1e-3f);
+  }
+
+  // Fully below
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 10.0f);
+    EXPECT_NEAR(cyl.Volume(), cyl.VolumeBelow(plane), 1e-3f);
+  }
+
+  // Fully above
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, -10.0f);
+    EXPECT_NEAR(0.0f, cyl.VolumeBelow(plane), 1e-3f);
+  }
+
+  // CenterOfVolumeBelow with float
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 0.0f);
+    auto cov = cyl.CenterOfVolumeBelow(plane);
+    ASSERT_TRUE(cov.has_value());
+    EXPECT_NEAR(0.0f, cov.value().X(), 1e-3f);
+    EXPECT_NEAR(0.0f, cov.value().Y(), 1e-3f);
+    EXPECT_NEAR(-1.0f, cov.value().Z(), 1e-3f);
+  }
+}

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -145,3 +145,39 @@ TEST(EllipsoidTest, Mass)
   const math::Ellipsoidd ellipsoid5(math::Vector3d(-1, -1, 1));
   EXPECT_EQ(std::nullopt, ellipsoid5.MassMatrix());
 }
+
+/////////////////////////////////////////////////
+TEST(EllipsoidTest, VolumeBelowFloat)
+{
+  // Use equal radii (sphere) for easy validation
+  math::Ellipsoid<float> ellipsoid(math::Vector3<float>(2.0f, 2.0f, 2.0f));
+
+  // Horizontal plane at z=0: half volume
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 0.0f);
+    EXPECT_NEAR(ellipsoid.Volume() / 2.0f,
+                ellipsoid.VolumeBelow(plane), 1e-3f);
+  }
+
+  // Fully below
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, 10.0f);
+    EXPECT_NEAR(ellipsoid.Volume(), ellipsoid.VolumeBelow(plane), 1e-3f);
+  }
+
+  // Fully above
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 0, 1}, -10.0f);
+    EXPECT_NEAR(0.0f, ellipsoid.VolumeBelow(plane), 1e-3f);
+  }
+
+  // CenterOfVolumeBelow with float
+  {
+    math::Plane<float> plane(math::Vector3<float>{0, 1, 0}, 0.0f);
+    auto cov = ellipsoid.CenterOfVolumeBelow(plane);
+    ASSERT_TRUE(cov.has_value());
+    EXPECT_NEAR(0.0f, cov.value().X(), 1e-3f);
+    EXPECT_NEAR(-0.75f, cov.value().Y(), 1e-3f);
+    EXPECT_NEAR(0.0f, cov.value().Z(), 1e-3f);
+  }
+}

--- a/src/python_pybind11/src/Capsule.hh
+++ b/src/python_pybind11/src/Capsule.hh
@@ -79,6 +79,13 @@ void helpDefineMathCapsule(py::module &m, const std::string &typestr)
     .def("volume",
          &Class::Volume,
          "Get the volume of the capsule in m^3.")
+    .def("volume_below",
+         &Class::VolumeBelow,
+         "Get the volume of the capsule below a plane.")
+    .def("center_of_volume_below",
+         &Class::CenterOfVolumeBelow,
+         "Center of volume below the plane. This is useful when "
+         "calculating where buoyancy should be applied, for example.")
     .def("density_from_mass",
          &Class::DensityFromMass,
          "Compute the box's density given a mass value.")

--- a/src/python_pybind11/src/Cylinder.hh
+++ b/src/python_pybind11/src/Cylinder.hh
@@ -91,6 +91,13 @@ void defineMathCylinder(py::module &m, const std::string &typestr)
     .def("volume",
          &Class::Volume,
          "Get the volume of the box in m^3.")
+    .def("volume_below",
+         &Class::VolumeBelow,
+         "Get the volume of the cylinder below a plane.")
+    .def("center_of_volume_below",
+         &Class::CenterOfVolumeBelow,
+         "Center of volume below the plane. This is useful when "
+         "calculating where buoyancy should be applied, for example.")
     .def("density_from_mass",
          &Class::DensityFromMass,
          "Compute the box's density given a mass value.")

--- a/src/python_pybind11/src/Ellipsoid.hh
+++ b/src/python_pybind11/src/Ellipsoid.hh
@@ -75,6 +75,13 @@ void helpDefineMathEllipsoid(py::module &m, const std::string &typestr)
     .def("volume",
          &Class::Volume,
          "Get the volume of the Ellipsoid in m^3.")
+    .def("volume_below",
+         &Class::VolumeBelow,
+         "Get the volume of the ellipsoid below a plane.")
+    .def("center_of_volume_below",
+         &Class::CenterOfVolumeBelow,
+         "Center of volume below the plane. This is useful when "
+         "calculating where buoyancy should be applied, for example.")
     .def("density_from_mass",
          &Class::DensityFromMass,
          "Compute the box's density given a mass value.")

--- a/src/python_pybind11/test/Capsule_TEST.py
+++ b/src/python_pybind11/test/Capsule_TEST.py
@@ -15,7 +15,7 @@
 import unittest
 
 import ignition
-from ignition.math import Capsuled, Material, MassMatrix3d
+from ignition.math import Capsuled, Material, MassMatrix3d, Planed, Vector3d
 
 import math
 
@@ -110,6 +110,44 @@ class TestBox(unittest.TestCase):
       self.assertEqual(expectedMassMat, massMat);
       self.assertEqual(expectedMassMat.diagonal_moments(), massMat.diagonal_moments());
       self.assertEqual(expectedMassMat.mass(), massMat.mass());
+
+    def test_volume_below(self):
+        length = 2.0
+        r = 1.0
+        capsule = Capsuled(length, r)
+
+        # Horizontal plane at z=0: half volume by symmetry
+        plane = Planed(Vector3d(0, 0, 1), 0)
+        self.assertAlmostEqual(
+            capsule.volume() / 2.0, capsule.volume_below(plane), delta=1e-3)
+
+        # Fully below
+        plane = Planed(Vector3d(0, 0, 1), 10.0)
+        self.assertAlmostEqual(
+            capsule.volume(), capsule.volume_below(plane), delta=1e-3)
+
+        # Fully above
+        plane = Planed(Vector3d(0, 0, 1), -10.0)
+        self.assertAlmostEqual(0.0, capsule.volume_below(plane), delta=1e-3)
+
+    def test_center_of_volume_below(self):
+        length = 2.0
+        r = 1.0
+        capsule = Capsuled(length, r)
+
+        # Horizontal plane at z=0
+        plane = Planed(Vector3d(0, 0, 1), 0)
+        cov = capsule.center_of_volume_below(plane)
+        self.assertTrue(cov is not None)
+        self.assertAlmostEqual(0.0, cov.x(), delta=1e-3)
+        self.assertAlmostEqual(0.0, cov.y(), delta=1e-3)
+        # Bottom half centroid is below z=0
+        self.assertTrue(cov.z() < 0.0)
+
+        # Fully above
+        plane = Planed(Vector3d(0, 0, 1), -10.0)
+        self.assertFalse(capsule.center_of_volume_below(plane) is not None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/python_pybind11/test/Cylinder_TEST.py
+++ b/src/python_pybind11/test/Cylinder_TEST.py
@@ -16,7 +16,7 @@ import math
 import unittest
 
 import ignition
-from ignition.math import Cylinderd, MassMatrix3d, Material, Quaterniond
+from ignition.math import Cylinderd, MassMatrix3d, Material, Planed, Quaterniond, Vector3d
 
 
 class TestCylinder(unittest.TestCase):
@@ -113,6 +113,43 @@ class TestCylinder(unittest.TestCase):
         cylinder.mass_matrix(massMat)
         self.assertEqual(expectedMassMat, massMat)
         self.assertEqual(expectedMassMat.mass(), massMat.mass())
+
+
+    def test_volume_below(self):
+        length = 4.0
+        r = 2.0
+        cylinder = Cylinderd(length, r)
+
+        # Horizontal plane at z=0: half volume
+        plane = Planed(Vector3d(0, 0, 1), 0)
+        self.assertAlmostEqual(
+            cylinder.volume() / 2.0, cylinder.volume_below(plane), delta=1e-3)
+
+        # Fully below
+        plane = Planed(Vector3d(0, 0, 1), 10.0)
+        self.assertAlmostEqual(
+            cylinder.volume(), cylinder.volume_below(plane), delta=1e-3)
+
+        # Fully above
+        plane = Planed(Vector3d(0, 0, 1), -10.0)
+        self.assertAlmostEqual(0.0, cylinder.volume_below(plane), delta=1e-3)
+
+    def test_center_of_volume_below(self):
+        length = 4.0
+        r = 2.0
+        cylinder = Cylinderd(length, r)
+
+        # Horizontal plane at z=0
+        plane = Planed(Vector3d(0, 0, 1), 0)
+        cov = cylinder.center_of_volume_below(plane)
+        self.assertTrue(cov is not None)
+        self.assertAlmostEqual(0.0, cov.x(), delta=1e-3)
+        self.assertAlmostEqual(0.0, cov.y(), delta=1e-3)
+        self.assertAlmostEqual(-1.0, cov.z(), delta=1e-3)
+
+        # Fully above
+        plane = Planed(Vector3d(0, 0, 1), -10.0)
+        self.assertFalse(cylinder.center_of_volume_below(plane) is not None)
 
 
 if __name__ == '__main__':

--- a/src/python_pybind11/test/Ellipsoid_TEST.py
+++ b/src/python_pybind11/test/Ellipsoid_TEST.py
@@ -15,7 +15,7 @@
 import unittest
 
 import ignition
-from ignition.math import Ellipsoidd, Material, MassMatrix3d, Vector3d
+from ignition.math import Ellipsoidd, Material, MassMatrix3d, Planed, Vector3d
 
 import math
 
@@ -125,6 +125,48 @@ class TestEllipsoid(unittest.TestCase):
 
         ellipsoid5 = Ellipsoidd(Vector3d(-1, -1, 1))
         self.assertEqual(None, ellipsoid5.mass_matrix())
+
+    def test_volume_below(self):
+        # Use equal radii (sphere) for easy validation
+        ellipsoid = Ellipsoidd(Vector3d(2.0, 2.0, 2.0))
+
+        # Horizontal plane at z=0: half volume
+        plane = Planed(Vector3d(0, 0, 1), 0)
+        self.assertAlmostEqual(
+            ellipsoid.volume() / 2.0, ellipsoid.volume_below(plane),
+            delta=1e-3)
+
+        # Fully below
+        plane = Planed(Vector3d(0, 0, 1), 10.0)
+        self.assertAlmostEqual(
+            ellipsoid.volume(), ellipsoid.volume_below(plane), delta=1e-3)
+
+        # Fully above
+        plane = Planed(Vector3d(0, 0, 1), -10.0)
+        self.assertAlmostEqual(0.0, ellipsoid.volume_below(plane), delta=1e-3)
+
+    def test_center_of_volume_below(self):
+        # Use equal radii (sphere) for easy validation
+        ellipsoid = Ellipsoidd(Vector3d(2.0, 2.0, 2.0))
+
+        # Hemisphere: center of volume for a hemisphere is 3/8 * r
+        plane = Planed(Vector3d(0, 1, 0), 0)
+        cov = ellipsoid.center_of_volume_below(plane)
+        self.assertTrue(cov is not None)
+        self.assertAlmostEqual(0.0, cov.x(), delta=1e-3)
+        self.assertAlmostEqual(-0.75, cov.y(), delta=1e-3)
+        self.assertAlmostEqual(0.0, cov.z(), delta=1e-3)
+
+        # Fully above
+        plane = Planed(Vector3d(0, 0, 1), -10.0)
+        self.assertFalse(ellipsoid.center_of_volume_below(plane) is not None)
+
+        # Entire ellipsoid below plane
+        plane = Planed(Vector3d(0, 0, 1), 10.0)
+        cov = ellipsoid.center_of_volume_below(plane)
+        self.assertTrue(cov is not None)
+        self.assertEqual(Vector3d(0, 0, 0), cov)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/ruby/Capsule.i
+++ b/src/ruby/Capsule.i
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2026 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  *
 */
 
-%module cylinder
+%module capsule
 %{
-#include <gz/math/Cylinder.hh>
+#include <gz/math/Capsule.hh>
 #include <gz/math/config.hh>
 #include <gz/math/MassMatrix3.hh>
 #include <gz/math/Material.hh>
-#include <gz/math/Quaternion.hh>
 #include <gz/math/Plane.hh>
 %}
 
@@ -43,22 +42,16 @@ namespace ignition
   namespace math
   {
     template<typename Precision>
-    class Cylinder
+    class Capsule
     {
       %rename("%(undercase)s", %$isfunction, notregexmatch$name="^[A-Z]*$") "";
 
-      public: Cylinder() = default;
+      public: Capsule() = default;
 
-      public: Cylinder(const Precision _length, const Precision _radius,
-                  const ignition::math::Quaternion<Precision> &_rotOffset =
-                  ignition::math::Quaternion<Precision>::Identity);
+      public: Capsule(const Precision _length, const Precision _radius);
 
-      public: Cylinder(const Precision _length, const Precision _radius,
-                  const ignition::math::Material &_mat,
-                  const ignition::math::Quaternion<Precision> &_rotOffset =
-                  ignition::math::Quaternion<Precision>::Identity);
-
-      public: ~Cylinder() = default;
+      public: Capsule(const Precision _length, const Precision _radius,
+                  const ignition::math::Material &_mat);
 
       public: Precision Radius() const;
 
@@ -68,18 +61,11 @@ namespace ignition
 
       public: void SetLength(const Precision _length);
 
-      public: ignition::math::Quaternion<Precision> RotationalOffset() const;
-
-      public: void SetRotationalOffset(
-                  const ignition::math::Quaternion<Precision> &_rotOffset);
-
       public: const ignition::math::Material &Mat() const;
 
       public: void SetMat(const ignition::math::Material &_mat);
 
-      public: bool MassMatrix(ignition::math::MassMatrix3<double> &_massMat) const;
-
-      public: bool operator==(const Cylinder &_cylinder) const;
+      public: bool operator==(const Capsule &_capsule) const;
 
       public: Precision Volume() const;
 
@@ -92,6 +78,6 @@ namespace ignition
 
       public: bool SetDensityFromMass(const Precision _mass);
     };
-    %template(Cylinderd) Cylinder<double>;
+    %template(Capsuled) Capsule<double>;
   }
 }

--- a/src/ruby/Ellipsoid.i
+++ b/src/ruby/Ellipsoid.i
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2026 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  *
 */
 
-%module cylinder
+%module ellipsoid
 %{
-#include <gz/math/Cylinder.hh>
+#include <gz/math/Ellipsoid.hh>
 #include <gz/math/config.hh>
 #include <gz/math/MassMatrix3.hh>
 #include <gz/math/Material.hh>
-#include <gz/math/Quaternion.hh>
 #include <gz/math/Plane.hh>
+#include <gz/math/Vector3.hh>
 %}
 
 %include "typemaps.i"
@@ -43,43 +43,26 @@ namespace ignition
   namespace math
   {
     template<typename Precision>
-    class Cylinder
+    class Ellipsoid
     {
       %rename("%(undercase)s", %$isfunction, notregexmatch$name="^[A-Z]*$") "";
 
-      public: Cylinder() = default;
+      public: Ellipsoid() = default;
 
-      public: Cylinder(const Precision _length, const Precision _radius,
-                  const ignition::math::Quaternion<Precision> &_rotOffset =
-                  ignition::math::Quaternion<Precision>::Identity);
+      public: explicit Ellipsoid(const ignition::math::Vector3<Precision> &_radii);
 
-      public: Cylinder(const Precision _length, const Precision _radius,
-                  const ignition::math::Material &_mat,
-                  const ignition::math::Quaternion<Precision> &_rotOffset =
-                  ignition::math::Quaternion<Precision>::Identity);
+      public: Ellipsoid(const ignition::math::Vector3<Precision> &_radii,
+                  const ignition::math::Material &_mat);
 
-      public: ~Cylinder() = default;
+      public: ignition::math::Vector3<Precision> Radii() const;
 
-      public: Precision Radius() const;
-
-      public: void SetRadius(const Precision _radius);
-
-      public: Precision Length() const;
-
-      public: void SetLength(const Precision _length);
-
-      public: ignition::math::Quaternion<Precision> RotationalOffset() const;
-
-      public: void SetRotationalOffset(
-                  const ignition::math::Quaternion<Precision> &_rotOffset);
+      public: void SetRadii(const ignition::math::Vector3<Precision> &_radii);
 
       public: const ignition::math::Material &Mat() const;
 
       public: void SetMat(const ignition::math::Material &_mat);
 
-      public: bool MassMatrix(ignition::math::MassMatrix3<double> &_massMat) const;
-
-      public: bool operator==(const Cylinder &_cylinder) const;
+      public: bool operator==(const Ellipsoid &_ellipsoid) const;
 
       public: Precision Volume() const;
 
@@ -92,6 +75,6 @@ namespace ignition
 
       public: bool SetDensityFromMass(const Precision _mass);
     };
-    %template(Cylinderd) Cylinder<double>;
+    %template(Ellipsoidd) Ellipsoid<double>;
   }
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Continuing with #724 , this patch extends the volume API (`VolumeBelow` and `CenterOfVolumeBelow`) — previously available only on `Sphere` and `Box` — to **Ellipsoid**, **Cylinder**, and **Capsule**.

Each shape computes the volume and centroid of the region below an arbitrary cutting plane, which is the key primitive needed for buoyancy force and torque calculations in simulation.

**Note:** This is a manual backport of #730 to `ign-math6` (Gazebo Fortress). Cone is excluded (not available in gz-math6). Adapted for `ignition::math` namespace, `IGN_PI`, `IGNITION_MATH_VERSION_NAMESPACE`, and `ignition.math` Python module name.

## Algorithms

| Shape | Complexity | Technique | Notes |
|---|---|---|---|
| **Ellipsoid** | O(1) | Affine map to unit sphere + spherical cap formula | 1 `sqrt`, 0 trig, 0 heap allocs |
| **Cylinder** | O(1) | Closed-form circular segment antiderivatives (Cavalieri's principle) | 2-5 trig calls, 0 heap allocs. Shared helpers in `WetVolume.hh` |
| **Capsule** | O(1) | Decomposes into Cylinder + 2 Sphere hemispheres | Stability guard for tiny hemisphere slices avoids catastrophic cancellation |

All implementations are header-only, zero-allocation, and suitable for real-time stepping.

## Changes

- **`detail/WetVolume.hh`** (new) — shared circular-segment and GL10 quadrature helpers.
- **`detail/{Ellipsoid,Cylinder,Capsule}.hh`** — `VolumeBelow` and `CenterOfVolumeBelow` implementations.
- **Public headers** — method declarations added.
- **C++ tests** — `VolumeBelowFloat` tests for all three shapes.
- **Python pybind11** — `volume_below` / `center_of_volume_below` bindings and tests for all three shapes.
- **Ruby SWIG** — `VolumeBelow` / `CenterOfVolumeBelow` added to `Cylinder.i`. New `Ellipsoid.i`, `Capsule.i` created (preparatory; not in active build).

## Test plan

- [ ] CI passes on all platforms

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Consider updating Python bindings (if the library has them)
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.