### PR TITLE
Use rotary alias packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,5 @@
-libgz-cmake-dev
-libgz-utils-dev
+libgz-rotary-cmake-dev
+libgz-rotary-utils-dev
 libeigen3-dev
 libpython3-dev
 python3-numpy


### PR DESCRIPTION
Use rotary alias packages for CI

Related to https://github.com/gazebo-tooling/release-tools/issues/1446