### PR TITLE
Use action-ros-ci to build from source

### DIFF
--- a/.github/workflows/ci_dependencies_from_source.yaml
+++ b/.github/workflows/ci_dependencies_from_source.yaml
@@ -1,0 +1,25 @@
+name: Ubuntu CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'ign-math[0-9]'
+      - 'gz-math[0-9]'
+      - 'main'
+
+jobs:
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI (from source)
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        uses: ros-tooling/action-ros-ci@v0.4
+        with:
+          package-name: gz-math
+          target-ros2-distro: kilted
+          vcs-repo-file-url: https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/gz-math9.yaml


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/action-gz-ci/issues/80

## Summary

This is an experiment to use action-ros-ci to build gazebo's dependencies from source, as this is currently not easy to do with action-gz-ci.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
