### PR TITLE
graph: add tree algorithms

### DIFF
--- a/include/gz/math/graph/GraphAlgorithms.hh
+++ b/include/gz/math/graph/GraphAlgorithms.hh
@@ -420,6 +420,48 @@ namespace graph
       cur = next;
     }
   }
+
+  /// \brief Lowest common ancestor of two vertices in a directed forest.
+  /// Walks `_a` up to root collecting ancestors, then walks `_b` up until
+  /// hitting one of those ancestors. O(depth_a + depth_b).
+  ///
+  /// Useful for relative-frame computation: if two entities live in the
+  /// same world tree, the LCA is the deepest shared frame, and a relative
+  /// pose can be composed by chaining transforms a->LCA and LCA->b.
+  ///
+  /// \param[in] _graph A directed graph (expected to be a forest).
+  /// \param[in] _a One vertex.
+  /// \param[in] _b Another vertex.
+  /// \return The LCA vertex id, or kNullId if the two vertices share no
+  /// common ancestor (different trees) or either is invalid. If `_a == _b`,
+  /// returns `_a`.
+  template<typename V, typename E, typename EdgeType>
+  VertexId LowestCommonAncestor(
+      const Graph<V, E, EdgeType> &_graph,
+      const VertexId &_a, const VertexId &_b)
+  {
+    if (!_graph.VertexFromId(_a).Valid() ||
+        !_graph.VertexFromId(_b).Valid())
+    {
+      return kNullId;
+    }
+    if (_a == _b)
+      return _a;
+
+    std::unordered_set<VertexId> ancestorsA;
+    ancestorsA.insert(_a);
+    for (auto v : Ancestors(_graph, _a))
+      ancestorsA.insert(v);
+
+    if (ancestorsA.count(_b))
+      return _b;
+    for (auto v : Ancestors(_graph, _b))
+    {
+      if (ancestorsA.count(v))
+        return v;
+    }
+    return kNullId;
+  }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE
 }  // namespace gz::math

--- a/include/gz/math/graph/GraphAlgorithms.hh
+++ b/include/gz/math/graph/GraphAlgorithms.hh
@@ -500,6 +500,37 @@ namespace graph
     }
     return out;
   }
+
+  /// \brief Set of all descendants of `_vertex` (including `_vertex`
+  /// itself). Equivalent to BreadthFirstSort + insert-into-set, but avoids
+  /// the intermediate vector copy. Matches the return shape downstream
+  /// consumers (gz-sim's EntityComponentManager::Descendants) use.
+  /// \param[in] _graph Source graph.
+  /// \param[in] _vertex Root vertex.
+  /// \return Set of vertex ids reachable from `_vertex`.
+  template<typename V, typename E, typename EdgeType>
+  std::unordered_set<VertexId> DescendantsSet(
+      const Graph<V, E, EdgeType> &_graph, const VertexId &_vertex)
+  {
+    std::unordered_set<VertexId> out;
+    if (!_graph.VertexFromId(_vertex).Valid())
+      return out;
+
+    std::queue<VertexId> pending;
+    pending.push(_vertex);
+    out.insert(_vertex);
+    while (!pending.empty())
+    {
+      const VertexId u = pending.front();
+      pending.pop();
+      for (auto const &adj : _graph.AdjacentsFrom(u))
+      {
+        if (out.insert(adj.first).second)
+          pending.push(adj.first);
+      }
+    }
+    return out;
+  }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE
 }  // namespace gz::math

--- a/include/gz/math/graph/GraphAlgorithms.hh
+++ b/include/gz/math/graph/GraphAlgorithms.hh
@@ -462,6 +462,44 @@ namespace graph
     }
     return kNullId;
   }
+
+  /// \brief Extract the subtree rooted at `_root` as a new graph of the
+  /// same type. Vertices and edges are copied (preserving ids, names, data,
+  /// weights). Equivalent to "save just this entity and everything beneath
+  /// it" -- the shape of operation gz-sim and sdformat would invoke when
+  /// serializing a single model out of a world.
+  ///
+  /// \param[in] _graph Source graph.
+  /// \param[in] _root Root vertex of the subtree.
+  /// \return A new graph containing `_root` and all descendants reachable
+  /// from it, plus the edges between them. Empty graph if `_root` is invalid.
+  template<typename V, typename E, typename EdgeType>
+  Graph<V, E, EdgeType> Subtree(
+      const Graph<V, E, EdgeType> &_graph, const VertexId &_root)
+  {
+    Graph<V, E, EdgeType> out;
+    if (!_graph.VertexFromId(_root).Valid())
+      return out;
+
+    auto descendants = BreadthFirstSort(_graph, _root);
+    std::unordered_set<VertexId> set(descendants.begin(), descendants.end());
+
+    // Copy vertices preserving ids.
+    for (auto id : descendants)
+    {
+      const auto &v = _graph.VertexFromId(id);
+      out.AddVertex(v.Name(), v.Data(), v.Id());
+    }
+    // Copy edges whose endpoints both lie in the subtree.
+    for (auto const &ePair : _graph.Edges())
+    {
+      auto const &e = ePair.second.get();
+      auto vs = e.Vertices();
+      if (set.count(vs.first) && set.count(vs.second))
+        out.AddEdge(vs, e.Data(), e.Weight());
+    }
+    return out;
+  }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE
 }  // namespace gz::math

--- a/include/gz/math/graph/GraphAlgorithms.hh
+++ b/include/gz/math/graph/GraphAlgorithms.hh
@@ -338,6 +338,48 @@ namespace graph
 
     return UndirectedGraph<V, E>(vertices, edges);
   }
+
+  /// \brief Walk parent edges from `_vertex` up to a root and return the
+  /// chain of ancestors in walk order (immediate parent first, root last).
+  /// In a tree this returns the unique parent chain; in a more general
+  /// directed graph it follows the *first* incoming edge at each step
+  /// (deterministic via the adjacency-list ordering) and aborts on cycles.
+  ///
+  /// This subsumes the hand-coded "walk to root" loops widely seen in
+  /// downstream code (e.g. gz-sim's worldPose / worldEntity / scopedName,
+  /// sdformat's FrameSemantics::FindSourceVertex).
+  ///
+  /// \param[in] _graph Any graph (typically a directed forest/tree).
+  /// \param[in] _vertex Starting vertex.
+  /// \return Vector of vertex ids: parent, grandparent, ..., root.
+  /// Empty if `_vertex` is invalid or has no parent. If a cycle is detected
+  /// (the same vertex visited twice), the partial chain up to the cycle
+  /// repeat is returned.
+  template<typename V, typename E, typename EdgeType>
+  std::vector<VertexId> Ancestors(
+      const Graph<V, E, EdgeType> &_graph, const VertexId &_vertex)
+  {
+    std::vector<VertexId> chain;
+    if (!_graph.VertexFromId(_vertex).Valid())
+      return chain;
+
+    std::unordered_set<VertexId> seen;
+    seen.insert(_vertex);
+    VertexId cur = _vertex;
+    while (true)
+    {
+      auto parents = _graph.AdjacentsTo(cur);
+      if (parents.empty())
+        break;
+      const VertexId next = parents.begin()->first;
+      // Cycle guard: stop if we revisit a vertex.
+      if (!seen.insert(next).second)
+        break;
+      chain.push_back(next);
+      cur = next;
+    }
+    return chain;
+  }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE
 }  // namespace gz::math

--- a/include/gz/math/graph/GraphAlgorithms.hh
+++ b/include/gz/math/graph/GraphAlgorithms.hh
@@ -340,7 +340,9 @@ namespace graph
   }
 
   /// \brief Walk parent edges from `_vertex` up to a root and return the
-  /// chain of ancestors in walk order (immediate parent first, root last).
+  /// chain of ancestors in walk order (immediate parent first, root last)
+  /// together with a flag indicating whether the walk terminated cleanly
+  /// at a root (no parent) or was aborted by the cycle guard.
   /// In a tree this returns the unique parent chain; in a more general
   /// directed graph it follows the *first* incoming edge at each step
   /// (deterministic via the adjacency-list ordering) and aborts on cycles.
@@ -351,17 +353,21 @@ namespace graph
   ///
   /// \param[in] _graph Any graph (typically a directed forest/tree).
   /// \param[in] _vertex Starting vertex.
-  /// \return Vector of vertex ids: parent, grandparent, ..., root.
-  /// Empty if `_vertex` is invalid or has no parent. If a cycle is detected
-  /// (the same vertex visited twice), the partial chain up to the cycle
-  /// repeat is returned.
+  /// \return A pair (chain, reachedRoot):
+  ///   - chain: vertex ids in walk order (parent, grandparent, ..., root).
+  ///     Empty if `_vertex` is invalid or has no parent.
+  ///   - reachedRoot: true if the walk terminated at a root (parent chain
+  ///     is complete). False if `_vertex` was invalid, or the walk was
+  ///     aborted because a previously visited vertex was reached again
+  ///     (cycle), in which case `chain` holds the partial path traversed
+  ///     up to the revisit.
   template<typename V, typename E, typename EdgeType>
-  std::vector<VertexId> Ancestors(
+  std::pair<std::vector<VertexId>, bool> Ancestors(
       const Graph<V, E, EdgeType> &_graph, const VertexId &_vertex)
   {
     std::vector<VertexId> chain;
     if (!_graph.VertexFromId(_vertex).Valid())
-      return chain;
+      return {chain, false};
 
     std::unordered_set<VertexId> seen;
     seen.insert(_vertex);
@@ -370,15 +376,14 @@ namespace graph
     {
       auto parents = _graph.AdjacentsTo(cur);
       if (parents.empty())
-        break;
+        return {chain, true};
       const VertexId next = parents.begin()->first;
       // Cycle guard: stop if we revisit a vertex.
       if (!seen.insert(next).second)
-        break;
+        return {chain, false};
       chain.push_back(next);
       cur = next;
     }
-    return chain;
   }
 
   /// \brief Test whether `_ancestor` lies on the parent chain above
@@ -450,12 +455,12 @@ namespace graph
 
     std::unordered_set<VertexId> ancestorsA;
     ancestorsA.insert(_a);
-    for (auto v : Ancestors(_graph, _a))
+    for (auto v : Ancestors(_graph, _a).first)
       ancestorsA.insert(v);
 
     if (ancestorsA.count(_b))
       return _b;
-    for (auto v : Ancestors(_graph, _b))
+    for (auto v : Ancestors(_graph, _b).first)
     {
       if (ancestorsA.count(v))
         return v;
@@ -463,18 +468,21 @@ namespace graph
     return kNullId;
   }
 
-  /// \brief Extract the subtree rooted at `_root` as a new graph of the
-  /// same type. Vertices and edges are copied (preserving ids, names, data,
-  /// weights). Equivalent to "save just this entity and everything beneath
-  /// it" -- the shape of operation gz-sim and sdformat would invoke when
-  /// serializing a single model out of a world.
+  /// \brief Extract the subgraph induced by `_root` and all descendants
+  /// reachable from it. Vertices and edges are copied (preserving ids,
+  /// names, data, weights). All edges whose endpoints both lie in the
+  /// reachable set are kept, including back-edges -- so if the source
+  /// graph contains cycles within the reachable region, the cycles are
+  /// preserved in the result. Equivalent to "save just this entity and
+  /// everything beneath it" -- the shape of operation gz-sim and sdformat
+  /// would invoke when serializing a single model out of a world.
   ///
   /// \param[in] _graph Source graph.
-  /// \param[in] _root Root vertex of the subtree.
+  /// \param[in] _root Root vertex of the subgraph.
   /// \return A new graph containing `_root` and all descendants reachable
   /// from it, plus the edges between them. Empty graph if `_root` is invalid.
   template<typename V, typename E, typename EdgeType>
-  Graph<V, E, EdgeType> Subtree(
+  Graph<V, E, EdgeType> Subgraph(
       const Graph<V, E, EdgeType> &_graph, const VertexId &_root)
   {
     Graph<V, E, EdgeType> out;
@@ -490,7 +498,7 @@ namespace graph
       const auto &v = _graph.VertexFromId(id);
       out.AddVertex(v.Name(), v.Data(), v.Id());
     }
-    // Copy edges whose endpoints both lie in the subtree.
+    // Copy edges whose endpoints both lie in the reachable set.
     for (auto const &ePair : _graph.Edges())
     {
       auto const &e = ePair.second.get();

--- a/include/gz/math/graph/GraphAlgorithms.hh
+++ b/include/gz/math/graph/GraphAlgorithms.hh
@@ -380,6 +380,46 @@ namespace graph
     }
     return chain;
   }
+
+  /// \brief Test whether `_ancestor` lies on the parent chain above
+  /// `_descendant`. O(depth) -- walks `_descendant` up via Ancestors() and
+  /// stops as soon as a match is found. Returns false for `_a == _d`
+  /// (consistent with the strict ancestor relation).
+  /// \param[in] _graph Any graph.
+  /// \param[in] _ancestor Candidate ancestor vertex id.
+  /// \param[in] _descendant Candidate descendant vertex id.
+  /// \return True if `_ancestor` is on the parent chain of `_descendant`.
+  template<typename V, typename E, typename EdgeType>
+  bool IsAncestor(
+      const Graph<V, E, EdgeType> &_graph,
+      const VertexId &_ancestor,
+      const VertexId &_descendant)
+  {
+    if (_ancestor == _descendant)
+      return false;
+    if (!_graph.VertexFromId(_ancestor).Valid() ||
+        !_graph.VertexFromId(_descendant).Valid())
+    {
+      return false;
+    }
+
+    std::unordered_set<VertexId> seen;
+    seen.insert(_descendant);
+    VertexId cur = _descendant;
+    while (true)
+    {
+      auto parents = _graph.AdjacentsTo(cur);
+      if (parents.empty())
+        return false;
+      const VertexId next = parents.begin()->first;
+      if (next == _ancestor)
+        return true;
+      // Cycle guard.
+      if (!seen.insert(next).second)
+        return false;
+      cur = next;
+    }
+  }
 }  // namespace graph
 }  // namespace GZ_MATH_VERSION_NAMESPACE
 }  // namespace gz::math

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -709,15 +709,15 @@ TEST(GraphAlgorithmsTree, Subgraph_ExtractsModel)
   g.AddEdge({1, 3}, 0.0); g.AddEdge({1, 4}, 0.0);
   g.AddEdge({2, 5}, 0.0);
 
-  // Extract the subtree rooted at modelA.
+  // Extract the subgraph rooted at modelA.
   auto sub = Subgraph(g, 1u);
   EXPECT_EQ(sub.Vertices().size(), 3u);  // modelA + linkA1 + linkA2
   EXPECT_EQ(sub.Edges().size(),    2u);  // modelA->linkA1, modelA->linkA2
   EXPECT_TRUE(sub.VertexFromId(1).Valid());
   EXPECT_TRUE(sub.VertexFromId(3).Valid());
   EXPECT_TRUE(sub.VertexFromId(4).Valid());
-  EXPECT_FALSE(sub.VertexFromId(0).Valid());  // world not in subtree
-  EXPECT_FALSE(sub.VertexFromId(5).Valid());  // linkB1 not in subtree
+  EXPECT_FALSE(sub.VertexFromId(0).Valid());  // world not in subgraph
+  EXPECT_FALSE(sub.VertexFromId(5).Valid());  // linkB1 not in subgraph
 
   // Data preserved.
   EXPECT_EQ(sub.VertexFromId(3).Data(), 30);

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -600,3 +600,72 @@ TEST(GraphAlgorithmsTree, IsAncestor_ToleratesCycle)
 
   EXPECT_FALSE(IsAncestor(g, 3u, 2u));
 }
+
+/////////////////////////////////////////////////
+// Tree algorithm: lowest common ancestor of two vertices in a forest.
+TEST(GraphAlgorithmsTree, LowestCommonAncestor)
+{
+  // world -> modelA -> linkA1
+  //                 -> linkA2
+  //       -> modelB -> linkB1
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 6; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  // 0 = world; 1 = modelA; 2 = modelB
+  // 3 = linkA1; 4 = linkA2; 5 = linkB1
+  g.AddEdge({0, 1}, 0.0); g.AddEdge({0, 2}, 0.0);
+  g.AddEdge({1, 3}, 0.0); g.AddEdge({1, 4}, 0.0);
+  g.AddEdge({2, 5}, 0.0);
+
+  // Two siblings under modelA -> LCA = modelA.
+  EXPECT_EQ(LowestCommonAncestor(g, 3u, 4u), 1u);
+  // linkA1 vs linkB1 -> LCA = world.
+  EXPECT_EQ(LowestCommonAncestor(g, 3u, 5u), 0u);
+  // Ancestor case: LCA(world, linkA1) = world.
+  EXPECT_EQ(LowestCommonAncestor(g, 0u, 3u), 0u);
+  // LCA(x, x) = x.
+  EXPECT_EQ(LowestCommonAncestor(g, 4u, 4u), 4u);
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: vertices in disjoint trees have no LCA.
+TEST(GraphAlgorithmsTree, LowestCommonAncestor_DisjointTrees)
+{
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 4; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  // Two disjoint chains: 0->1, 2->3.
+  g.AddEdge({0, 1}, 0.0); g.AddEdge({2, 3}, 0.0);
+
+  EXPECT_EQ(LowestCommonAncestor(g, 1u, 3u), kNullId);
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: LCA returns kNullId when either input is invalid.
+TEST(GraphAlgorithmsTree, LowestCommonAncestor_InvalidInputs)
+{
+  DirectedGraph<int, double> g;
+  g.AddVertex("v0", 0, 0);
+  g.AddVertex("v1", 1, 1);
+  g.AddEdge({0, 1}, 0.0);
+
+  EXPECT_EQ(LowestCommonAncestor(g, 99u, 1u), kNullId);
+  EXPECT_EQ(LowestCommonAncestor(g, 0u, 99u), kNullId);
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: LCA hits the early-return shortcut when `_b` is itself
+// an ancestor of `_a`.
+TEST(GraphAlgorithmsTree, LowestCommonAncestor_BIsAncestorOfA)
+{
+  // 0 -> 1 -> 2 -> 3
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 4; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  g.AddEdge({0, 1}, 0.0);
+  g.AddEdge({1, 2}, 0.0);
+  g.AddEdge({2, 3}, 0.0);
+
+  // _a = 3 (deep leaf), _b = 1 (its grandparent) -- _b is on _a's chain.
+  EXPECT_EQ(LowestCommonAncestor(g, 3u, 1u), 1u);
+}

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -550,3 +550,53 @@ TEST(GraphAlgorithmsTree, Ancestors_ToleratesCycle)
   EXPECT_EQ(chain[0], 1u);
   EXPECT_EQ(chain[1], 0u);
 }
+
+/////////////////////////////////////////////////
+// Tree algorithm: IsAncestor walks the descendant up its parent chain.
+TEST(GraphAlgorithmsTree, IsAncestor)
+{
+  // world(0) -> modelA(1) -> linkA(3)
+  // world(0) -> modelB(2) -> linkB(4)
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 5; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  g.AddEdge({0, 1}, 0.0); g.AddEdge({1, 3}, 0.0);
+  g.AddEdge({0, 2}, 0.0); g.AddEdge({2, 4}, 0.0);
+
+  EXPECT_TRUE(IsAncestor(g, 0u, 3u));   // world is ancestor of linkA
+  EXPECT_TRUE(IsAncestor(g, 1u, 3u));   // modelA is ancestor of linkA
+  EXPECT_FALSE(IsAncestor(g, 1u, 4u));  // modelA is NOT ancestor of linkB
+  EXPECT_FALSE(IsAncestor(g, 3u, 1u));  // child is not ancestor of parent
+  EXPECT_FALSE(IsAncestor(g, 0u, 0u));  // strict ancestor (a != d)
+  EXPECT_FALSE(IsAncestor(g, 99u, 3u));  // bogus inputs
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: IsAncestor must reject an invalid descendant id.
+TEST(GraphAlgorithmsTree, IsAncestor_InvalidDescendant)
+{
+  DirectedGraph<int, double> g;
+  g.AddVertex("v0", 0, 0);
+  g.AddVertex("v1", 1, 1);
+  g.AddEdge({0, 1}, 0.0);
+
+  EXPECT_FALSE(IsAncestor(g, 0u, 99u));
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: IsAncestor must terminate when the descendant chain
+// contains a cycle that does not include the candidate ancestor.
+TEST(GraphAlgorithmsTree, IsAncestor_ToleratesCycle)
+{
+  DirectedGraph<int, double> g;
+  g.AddVertex("v0", 0, 0);
+  g.AddVertex("v1", 1, 1);
+  g.AddVertex("v2", 2, 2);
+  g.AddVertex("v3", 3, 3);  // isolated -- the candidate ancestor.
+  // Cycle 0 -> 1 -> 2 -> 0, none of which connect to vertex 3.
+  g.AddEdge({0, 1}, 0.0);
+  g.AddEdge({1, 2}, 0.0);
+  g.AddEdge({2, 0}, 0.0);
+
+  EXPECT_FALSE(IsAncestor(g, 3u, 2u));
+}

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <string>
+#include <unordered_set>
 
 #include "gz/math/graph/Graph.hh"
 #include "gz/math/graph/GraphAlgorithms.hh"
@@ -709,4 +710,33 @@ TEST(GraphAlgorithmsTree, Subtree_InvalidRoot)
   auto sub = Subtree(g, 99u);
   EXPECT_TRUE(sub.Vertices().empty());
   EXPECT_TRUE(sub.Edges().empty());
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: DescendantsSet returns the same vertex set as a
+// BreadthFirstSort copy into a set.
+TEST(GraphAlgorithmsTree, DescendantsSet_AgreesWithBFS)
+{
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 5; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  g.AddEdge({0, 1}, 0.0); g.AddEdge({0, 2}, 0.0);
+  g.AddEdge({1, 3}, 0.0); g.AddEdge({2, 4}, 0.0);
+
+  auto bfs = BreadthFirstSort(g, 0u);
+  std::unordered_set<VertexId> bfsSet(bfs.begin(), bfs.end());
+  auto desc = DescendantsSet(g, 0u);
+  EXPECT_EQ(desc, bfsSet);
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: DescendantsSet returns an empty set for an invalid id.
+TEST(GraphAlgorithmsTree, DescendantsSet_InvalidVertex)
+{
+  DirectedGraph<int, double> g;
+  g.AddVertex("v0", 0, 0);
+  g.AddVertex("v1", 1, 1);
+  g.AddEdge({0, 1}, 0.0);
+
+  EXPECT_TRUE(DescendantsSet(g, 99u).empty());
 }

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -516,6 +516,7 @@ TEST(GraphAlgorithmsCoverage, BFS_DFS_SparseHighIds)
 
 /////////////////////////////////////////////////
 // Tree algorithm: walk the parent chain of a leaf back to the root.
+// Verifies both the chain contents and the reachedRoot flag.
 TEST(GraphAlgorithmsTree, Ancestors_LinearChain)
 {
   // 0 - 1 - 2 - 3   (parent pointers; AddEdge follows parent->child).
@@ -526,15 +527,38 @@ TEST(GraphAlgorithmsTree, Ancestors_LinearChain)
   g.AddEdge({1, 2}, 0.0);
   g.AddEdge({2, 3}, 0.0);
 
-  EXPECT_EQ(Ancestors(g, 3u), (std::vector<VertexId>{2, 1, 0}));
-  EXPECT_EQ(Ancestors(g, 1u), (std::vector<VertexId>{0}));
-  EXPECT_EQ(Ancestors(g, 0u), std::vector<VertexId>{});
-  EXPECT_EQ(Ancestors(g, 99u), std::vector<VertexId>{});
+  // Deep leaf: walks to root cleanly.
+  auto r = Ancestors(g, 3u);
+  EXPECT_EQ(r.first, (std::vector<VertexId>{2, 1, 0}));
+  EXPECT_TRUE(r.second);
+
+  // Mid-chain: walks to root cleanly.
+  r = Ancestors(g, 1u);
+  EXPECT_EQ(r.first, (std::vector<VertexId>{0}));
+  EXPECT_TRUE(r.second);
+
+  // Root vertex itself: empty chain, but reachedRoot is true (already at root).
+  r = Ancestors(g, 0u);
+  EXPECT_TRUE(r.first.empty());
+  EXPECT_TRUE(r.second);
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: invalid input vertex returns an empty chain with
+// reachedRoot=false (the walk could not start).
+TEST(GraphAlgorithmsTree, Ancestors_InvalidVertex)
+{
+  DirectedGraph<int, double> g;
+  g.AddVertex("v0", 0, 0);
+  auto r = Ancestors(g, 99u);
+  EXPECT_TRUE(r.first.empty());
+  EXPECT_FALSE(r.second);
 }
 
 /////////////////////////////////////////////////
 // Tree algorithm: Ancestors() must terminate even if the graph contains
-// a cycle. The chain returned stops at the first revisit.
+// a cycle. The chain returned stops at the first revisit and reachedRoot
+// is false to flag the cycle abort.
 TEST(GraphAlgorithmsTree, Ancestors_ToleratesCycle)
 {
   DirectedGraph<int, double> g;
@@ -546,10 +570,11 @@ TEST(GraphAlgorithmsTree, Ancestors_ToleratesCycle)
 
   // Walking up from 2: parent is 1, then 0; the cycle would re-visit 2,
   // which is the seen sentinel -- stop without infinite loop.
-  auto chain = Ancestors(g, 2u);
-  EXPECT_EQ(chain.size(), 2u);
-  EXPECT_EQ(chain[0], 1u);
-  EXPECT_EQ(chain[1], 0u);
+  auto r = Ancestors(g, 2u);
+  EXPECT_EQ(r.first.size(), 2u);
+  EXPECT_EQ(r.first[0], 1u);
+  EXPECT_EQ(r.first[1], 0u);
+  EXPECT_FALSE(r.second);
 }
 
 /////////////////////////////////////////////////
@@ -672,8 +697,8 @@ TEST(GraphAlgorithmsTree, LowestCommonAncestor_BIsAncestorOfA)
 }
 
 /////////////////////////////////////////////////
-// Tree algorithm: Subtree extracts the subtree rooted at a vertex.
-TEST(GraphAlgorithmsTree, Subtree_ExtractsModel)
+// Tree algorithm: Subgraph extracts the reachable region rooted at a vertex.
+TEST(GraphAlgorithmsTree, Subgraph_ExtractsModel)
 {
   // world -> modelA -> linkA1, linkA2
   //       -> modelB -> linkB1
@@ -685,7 +710,7 @@ TEST(GraphAlgorithmsTree, Subtree_ExtractsModel)
   g.AddEdge({2, 5}, 0.0);
 
   // Extract the subtree rooted at modelA.
-  auto sub = Subtree(g, 1u);
+  auto sub = Subgraph(g, 1u);
   EXPECT_EQ(sub.Vertices().size(), 3u);  // modelA + linkA1 + linkA2
   EXPECT_EQ(sub.Edges().size(),    2u);  // modelA->linkA1, modelA->linkA2
   EXPECT_TRUE(sub.VertexFromId(1).Valid());
@@ -699,17 +724,40 @@ TEST(GraphAlgorithmsTree, Subtree_ExtractsModel)
 }
 
 /////////////////////////////////////////////////
-// Tree algorithm: Subtree returns an empty graph for an invalid root.
-TEST(GraphAlgorithmsTree, Subtree_InvalidRoot)
+// Tree algorithm: Subgraph returns an empty graph for an invalid root.
+TEST(GraphAlgorithmsTree, Subgraph_InvalidRoot)
 {
   DirectedGraph<int, double> g;
   g.AddVertex("v0", 0, 0);
   g.AddVertex("v1", 1, 1);
   g.AddEdge({0, 1}, 0.0);
 
-  auto sub = Subtree(g, 99u);
+  auto sub = Subgraph(g, 99u);
   EXPECT_TRUE(sub.Vertices().empty());
   EXPECT_TRUE(sub.Edges().empty());
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: Subgraph preserves cycles within the reachable region.
+// (This is the reason the function is named Subgraph and not Subtree:
+// the result is not necessarily a tree.)
+TEST(GraphAlgorithmsTree, Subgraph_PreservesCycles)
+{
+  // Reachable region forms a cycle: 0 -> 1 -> 2 -> 0, plus a chain
+  // hanging off vertex 1. All four vertices reachable from 0.
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 4; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  g.AddEdge({0, 1}, 0.0);
+  g.AddEdge({1, 2}, 0.0);
+  g.AddEdge({2, 0}, 0.0);  // back-edge closing the cycle
+  g.AddEdge({1, 3}, 0.0);
+
+  auto sub = Subgraph(g, 0u);
+  EXPECT_EQ(sub.Vertices().size(), 4u);
+  // All four edges (including the back-edge that forms the cycle) preserved.
+  EXPECT_EQ(sub.Edges().size(), 4u);
+  EXPECT_TRUE(sub.EdgeFromVertices(2u, 0u).Valid());
 }
 
 /////////////////////////////////////////////////

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -512,3 +512,41 @@ TEST(GraphAlgorithmsCoverage, BFS_DFS_SparseHighIds)
   auto dfs = DepthFirstSort(g, 1000000);
   EXPECT_EQ(dfs.size(), 3u);
 }
+
+/////////////////////////////////////////////////
+// Tree algorithm: walk the parent chain of a leaf back to the root.
+TEST(GraphAlgorithmsTree, Ancestors_LinearChain)
+{
+  // 0 - 1 - 2 - 3   (parent pointers; AddEdge follows parent->child).
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 4; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  g.AddEdge({0, 1}, 0.0);
+  g.AddEdge({1, 2}, 0.0);
+  g.AddEdge({2, 3}, 0.0);
+
+  EXPECT_EQ(Ancestors(g, 3u), (std::vector<VertexId>{2, 1, 0}));
+  EXPECT_EQ(Ancestors(g, 1u), (std::vector<VertexId>{0}));
+  EXPECT_EQ(Ancestors(g, 0u), std::vector<VertexId>{});
+  EXPECT_EQ(Ancestors(g, 99u), std::vector<VertexId>{});
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: Ancestors() must terminate even if the graph contains
+// a cycle. The chain returned stops at the first revisit.
+TEST(GraphAlgorithmsTree, Ancestors_ToleratesCycle)
+{
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 3; ++i)
+    g.AddVertex("v" + std::to_string(i), i, i);
+  g.AddEdge({0, 1}, 0.0);
+  g.AddEdge({1, 2}, 0.0);
+  g.AddEdge({2, 0}, 0.0);  // cycle back to 0
+
+  // Walking up from 2: parent is 1, then 0; the cycle would re-visit 2,
+  // which is the seen sentinel -- stop without infinite loop.
+  auto chain = Ancestors(g, 2u);
+  EXPECT_EQ(chain.size(), 2u);
+  EXPECT_EQ(chain[0], 1u);
+  EXPECT_EQ(chain[1], 0u);
+}

--- a/src/graph/GraphAlgorithms_TEST.cc
+++ b/src/graph/GraphAlgorithms_TEST.cc
@@ -669,3 +669,44 @@ TEST(GraphAlgorithmsTree, LowestCommonAncestor_BIsAncestorOfA)
   // _a = 3 (deep leaf), _b = 1 (its grandparent) -- _b is on _a's chain.
   EXPECT_EQ(LowestCommonAncestor(g, 3u, 1u), 1u);
 }
+
+/////////////////////////////////////////////////
+// Tree algorithm: Subtree extracts the subtree rooted at a vertex.
+TEST(GraphAlgorithmsTree, Subtree_ExtractsModel)
+{
+  // world -> modelA -> linkA1, linkA2
+  //       -> modelB -> linkB1
+  DirectedGraph<int, double> g;
+  for (int i = 0; i < 6; ++i)
+    g.AddVertex("v" + std::to_string(i), i * 10, i);
+  g.AddEdge({0, 1}, 0.0); g.AddEdge({0, 2}, 0.0);
+  g.AddEdge({1, 3}, 0.0); g.AddEdge({1, 4}, 0.0);
+  g.AddEdge({2, 5}, 0.0);
+
+  // Extract the subtree rooted at modelA.
+  auto sub = Subtree(g, 1u);
+  EXPECT_EQ(sub.Vertices().size(), 3u);  // modelA + linkA1 + linkA2
+  EXPECT_EQ(sub.Edges().size(),    2u);  // modelA->linkA1, modelA->linkA2
+  EXPECT_TRUE(sub.VertexFromId(1).Valid());
+  EXPECT_TRUE(sub.VertexFromId(3).Valid());
+  EXPECT_TRUE(sub.VertexFromId(4).Valid());
+  EXPECT_FALSE(sub.VertexFromId(0).Valid());  // world not in subtree
+  EXPECT_FALSE(sub.VertexFromId(5).Valid());  // linkB1 not in subtree
+
+  // Data preserved.
+  EXPECT_EQ(sub.VertexFromId(3).Data(), 30);
+}
+
+/////////////////////////////////////////////////
+// Tree algorithm: Subtree returns an empty graph for an invalid root.
+TEST(GraphAlgorithmsTree, Subtree_InvalidRoot)
+{
+  DirectedGraph<int, double> g;
+  g.AddVertex("v0", 0, 0);
+  g.AddVertex("v1", 1, 1);
+  g.AddEdge({0, 1}, 0.0);
+
+  auto sub = Subtree(g, 99u);
+  EXPECT_TRUE(sub.Vertices().empty());
+  EXPECT_TRUE(sub.Edges().empty());
+}

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -14,6 +14,7 @@ if (GzBenchmark_FOUND)
   set(tests
     graph.cc
     gz_sim_workload.cc
+    tree_algorithms.cc
   )
 
   gz_add_benchmarks(SOURCES ${tests})

--- a/test/benchmark/tree_algorithms.cc
+++ b/test/benchmark/tree_algorithms.cc
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+// Benchmarks for the tree-shaped algorithms (Ancestors, IsAncestor,
+// LowestCommonAncestor, Subtree, DescendantsSet) on a gz-sim-shaped
+// entity tree. For stable numbers, pin to a single CPU using your
+// platform's affinity tool (on Linux, e.g.,
+// `taskset -c 1 ./bin/BENCHMARK_tree_algorithms`).
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <string>
+
+#include "gz/math/graph/Graph.hh"
+#include "gz/math/graph/GraphAlgorithms.hh"
+
+using namespace gz;
+using namespace math;
+using namespace graph;
+
+namespace {
+
+using SimGraph = DirectedGraph<int, double>;
+
+/// \brief Build a gz-sim-flavored entity tree: world -> models -> links ->
+/// leaves. 1 + 50 + 500 + 2500 = 3051 entities, depth 3 from world.
+SimGraph makeSimEntityTree()
+{
+  SimGraph g;
+  VertexId nextId = 0;
+  const VertexId world = nextId++;
+  g.AddVertex("world", 0, world);
+  for (std::size_t m = 0; m < 50; ++m)
+  {
+    const VertexId model = nextId++;
+    g.AddVertex("model" + std::to_string(m), 0, model);
+    g.AddEdge({world, model}, 0.0, 1.0);
+    for (std::size_t l = 0; l < 10; ++l)
+    {
+      const VertexId link = nextId++;
+      g.AddVertex("link", 0, link);
+      g.AddEdge({model, link}, 0.0, 1.0);
+      for (std::size_t k = 0; k < 5; ++k)
+      {
+        const VertexId leaf = nextId++;
+        g.AddVertex("leaf", 0, leaf);
+        g.AddEdge({link, leaf}, 0.0, 1.0);
+      }
+    }
+  }
+  return g;
+}
+
+// Vertex ids in makeSimEntityTree():
+//   0   : world
+//   1   : model0
+//   3   : first leaf of model0's first link
+//   64  : first leaf of model1's first link
+//   3050: last entity in the tree (a deep leaf)
+constexpr VertexId kWorld = 0;
+constexpr VertexId kModel0 = 1;
+constexpr VertexId kLeafM0 = 3;
+constexpr VertexId kLeafM1 = 64;
+constexpr VertexId kDeepLeaf = 3050;
+
+}  // namespace
+
+/////////////////////////////////////////////////
+static void BM_AncestorsDeepLeaf(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  for (auto _ : _state)
+  {
+    auto chain = Ancestors(g, kDeepLeaf);
+    benchmark::DoNotOptimize(chain);
+  }
+}
+BENCHMARK(BM_AncestorsDeepLeaf);
+
+/////////////////////////////////////////////////
+static void BM_IsAncestorWorldLeaf(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  for (auto _ : _state)
+  {
+    bool r = IsAncestor(g, kWorld, kDeepLeaf);
+    benchmark::DoNotOptimize(r);
+  }
+}
+BENCHMARK(BM_IsAncestorWorldLeaf);
+
+/////////////////////////////////////////////////
+static void BM_LowestCommonAncestorCrossModel(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  for (auto _ : _state)
+  {
+    auto lca = LowestCommonAncestor(g, kLeafM0, kLeafM1);
+    benchmark::DoNotOptimize(lca);
+  }
+}
+BENCHMARK(BM_LowestCommonAncestorCrossModel);
+
+/////////////////////////////////////////////////
+static void BM_LowestCommonAncestorSameModel(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  // Both leaves under model0 but different links.
+  for (auto _ : _state)
+  {
+    auto lca = LowestCommonAncestor(g, VertexId{3}, VertexId{9});
+    benchmark::DoNotOptimize(lca);
+  }
+}
+BENCHMARK(BM_LowestCommonAncestorSameModel);
+
+/////////////////////////////////////////////////
+static void BM_SubtreeModel0(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  for (auto _ : _state)
+  {
+    auto sub = Subtree(g, kModel0);
+    benchmark::DoNotOptimize(sub);
+  }
+}
+BENCHMARK(BM_SubtreeModel0);
+
+/////////////////////////////////////////////////
+static void BM_DescendantsSetWorld(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  for (auto _ : _state)
+  {
+    auto set = DescendantsSet(g, kWorld);
+    benchmark::DoNotOptimize(set);
+  }
+}
+BENCHMARK(BM_DescendantsSetWorld);
+
+/////////////////////////////////////////////////
+static void BM_DescendantsSetModel0(benchmark::State &_state)
+{
+  auto g = makeSimEntityTree();
+  for (auto _ : _state)
+  {
+    auto set = DescendantsSet(g, kModel0);
+    benchmark::DoNotOptimize(set);
+  }
+}
+BENCHMARK(BM_DescendantsSetModel0);
+
+BENCHMARK_MAIN();

--- a/test/benchmark/tree_algorithms.cc
+++ b/test/benchmark/tree_algorithms.cc
@@ -16,7 +16,7 @@
 */
 
 // Benchmarks for the tree-shaped algorithms (Ancestors, IsAncestor,
-// LowestCommonAncestor, Subtree, DescendantsSet) on a gz-sim-shaped
+// LowestCommonAncestor, Subgraph, DescendantsSet) on a gz-sim-shaped
 // entity tree. For stable numbers, pin to a single CPU using your
 // platform's affinity tool (on Linux, e.g.,
 // `taskset -c 1 ./bin/BENCHMARK_tree_algorithms`).
@@ -130,16 +130,16 @@ static void BM_LowestCommonAncestorSameModel(benchmark::State &_state)
 BENCHMARK(BM_LowestCommonAncestorSameModel);
 
 /////////////////////////////////////////////////
-static void BM_SubtreeModel0(benchmark::State &_state)
+static void BM_SubgraphModel0(benchmark::State &_state)
 {
   auto g = makeSimEntityTree();
   for (auto _ : _state)
   {
-    auto sub = Subtree(g, kModel0);
+    auto sub = Subgraph(g, kModel0);
     benchmark::DoNotOptimize(sub);
   }
 }
-BENCHMARK(BM_SubtreeModel0);
+BENCHMARK(BM_SubgraphModel0);
 
 /////////////////////////////////////////////////
 static void BM_DescendantsSetWorld(benchmark::State &_state)


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

This patch adds five tree helper functions for `gz::math::graph`, split into six atomic commits for review:

* [`d44f5b66`](https://github.com/gazebosim/gz-math/pull/759/commits/d44f5b66f8d4456e61c7d36b11bf80bfbec4d930) `Ancestors(g, v)`. Walks parent edges from `v` up to a root and returns the chain of ancestors (immediate parent first, root last). Cycle safe via a local seen set.
* [`403144ee`](https://github.com/gazebosim/gz-math/pull/759/commits/403144ee426f5853690c686068ce8a2b67bbd625) `IsAncestor(g, anc, desc)`. O(depth) strict ancestor test (returns false for `anc == desc`).
* [`ac7a6875`](https://github.com/gazebosim/gz-math/pull/759/commits/ac7a6875153e0b36ce7f6a434ac77c23f7a4e609) `LowestCommonAncestor(g, a, b)`. Deepest shared ancestor of two vertices in a tree, or `kNullId` when they live in different trees.
* [`093a0f49`](https://github.com/gazebosim/gz-math/pull/759/commits/093a0f495e19e446de04fcc2e0af5df82238fa42) `Subtree(g, root)`. Extracts the subtree rooted at `root` as a new graph (preserves ids, names, data, weights).
* [`67900222`](https://github.com/gazebosim/gz-math/pull/759/commits/67900222fe75623048d079263449ca80768a7f51) `DescendantsSet(g, v)`. Flat `unordered_set<VertexId>` of `v` and all reachable descendants. Same shape as gz-sim's `EntityComponentManager::Descendants`.
* [`480b140d`](https://github.com/gazebosim/gz-math/pull/759/commits/480b140de27b546e8e9adb2c5d408e73bc621cea) Benchmark binary covering all five helpers.

Motivation: gz-sim's `worldPose` / `worldEntity` / `topLevelModel` / `scopedName` and sdformat's `FrameSemantics::FindSourceVertex` all reinvent the parent walk loop. These helpers consolidate that pattern with cycle protection.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

