### PR TITLE
graph: fix Graph::RemoveVertices(name) after SetName()

### DIFF
--- a/include/gz/math/graph/Graph.hh
+++ b/include/gz/math/graph/Graph.hh
@@ -179,9 +179,6 @@ namespace graph
       // Link the vertex with an empty list of edges.
       this->adjList[id] = EdgeId_S();
 
-      // Update the map of names.
-      this->names.insert(std::make_pair(_name, id));
-
       return ret.first->second;
     }
 
@@ -517,8 +514,6 @@ namespace graph
       if (vIt == this->vertices.end())
         return false;
 
-      std::string name = vIt->second.Name();
-
       // Remove incident edges.
       auto incidents = this->IncidentsTo(_vertex);
       for (auto edgePair : incidents)
@@ -534,17 +529,6 @@ namespace graph
 
       // Remove the vertex.
       this->vertices.erase(_vertex);
-
-      // Get an iterator to all vertices sharing name.
-      auto iterPair = this->names.equal_range(name);
-      for (auto it = iterPair.first; it != iterPair.second; ++it)
-      {
-        if (it->second == _vertex)
-        {
-          this->names.erase(it);
-          break;
-        }
-      }
 
       return true;
     }
@@ -562,14 +546,12 @@ namespace graph
     /// \return The number of vertices removed.
     public: size_t RemoveVertices(const std::string &_name)
     {
-      // Collect matching ids first so we don't mutate the names index
-      // (and the iterators it produces) while still reading from it.
-      auto range = this->names.equal_range(_name);
       std::vector<VertexId> toRemove;
-      toRemove.reserve(static_cast<std::size_t>(
-          std::distance(range.first, range.second)));
-      for (auto it = range.first; it != range.second; ++it)
-        toRemove.push_back(it->second);
+      for (auto const &[id, vertex] : this->vertices)
+      {
+        if (vertex.Name() == _name)
+          toRemove.push_back(id);
+      }
 
       size_t result = 0;
       for (auto const &id : toRemove)
@@ -763,9 +745,6 @@ namespace graph
     /// the edges (e) with Id (eId) represents a connected path from (v) to
     /// another vertex via (e).
     private: std::map<VertexId, EdgeId_S> adjList;
-
-    /// \brief Association between names and vertices currently used.
-    private: std::multimap<std::string, VertexId> names;
   };
 
   /////////////////////////////////////////////////

--- a/src/graph/Graph_TEST.cc
+++ b/src/graph/Graph_TEST.cc
@@ -457,3 +457,27 @@ TYPED_TEST(GraphTestFixture, EdgelessOutDegree)
     EXPECT_EQ(0u, graph.OutDegree(idVertex.first));
   }
 }
+
+/////////////////////////////////////////////////
+// Regression: renaming a graph-owned vertex via Vertex::SetName and
+// then removing it via Graph::RemoveVertices(name) must find the
+// vertex under its new name. Pre-fix, RemoveVertices read from an
+// internal name->id index that SetName did not update, so the
+// rename made the vertex un-removable by name (silent 0-return).
+TEST(GraphTest, RemoveVerticesAfterSetNameWorks)
+{
+  UndirectedGraph<int, double> graph;
+  graph.AddVertex("alice", 0, 0);
+  graph.AddVertex("bob",   1, 1);
+
+  // Rename through the mutable reference handed back by VertexFromId.
+  graph.VertexFromId(0).SetName("alice2");
+
+  // The vertex must be reachable under the new name.
+  EXPECT_EQ(1u, graph.RemoveVertices("alice2"));
+  EXPECT_FALSE(graph.VertexFromId(0).Valid());
+  // Removing under the old name is a no-op now.
+  EXPECT_EQ(0u, graph.RemoveVertices("alice"));
+  // Bob is untouched.
+  EXPECT_TRUE(graph.VertexFromId(1).Valid());
+}


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch fixes a bug in `Graph::RemoveVertices(name)`.  The graph kept an internal `name -> id` multimap. `RemoveVertices(name)` was reading from it.  `Vertex::SetName(...)` only updates the vertex object, so the graph never gets notified, so the multimap becomes incorrect after a rename.

The fix simplifies the code by removing the `names` multimap and using `Vertices()` instead.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
