### PR TITLE
graph: add virtual destructor to Edge<E>

### DIFF
--- a/include/gz/math/graph/Edge.hh
+++ b/include/gz/math/graph/Edge.hh
@@ -88,6 +88,14 @@ namespace graph
     {
     }
 
+    /// \brief Virtual destructor. Required because `Edge<E>` already has
+    /// virtual member functions (`From`, `To`), so polymorphic deletion
+    /// via a base `Edge<E>*` would otherwise be undefined behavior
+    /// (C++ Core Guideline C.35). With this defaulted virtual dtor,
+    /// `std::unique_ptr<Edge<E>>` and similar polymorphic owners are
+    /// safe.
+    public: virtual ~Edge() = default;
+
     /// \brief Get the edge Id.
     /// \return The edge Id.
     public: [[nodiscard]] EdgeId Id() const noexcept

--- a/src/graph/Edge_TEST.cc
+++ b/src/graph/Edge_TEST.cc
@@ -17,7 +17,9 @@
 
 #include <gtest/gtest.h>
 #include <iostream>
+#include <memory>
 #include <string>
+#include <type_traits>
 
 #include "gz/math/graph/Edge.hh"
 #include "gz/math/graph/Vertex.hh"
@@ -222,4 +224,26 @@ TEST(EdgeTest, StreamInsertionUndirected)
 
   std::string expectedOutput = "  0 -- 1 [label=2];\n";
   EXPECT_EQ(expectedOutput, output.str());
+}
+
+/////////////////////////////////////////////////
+// Edge<E> has virtual member functions (From, To) and now a virtual
+// destructor; verify the trait and confirm polymorphic deletion via a
+// base-class pointer is safe (would be undefined behavior without it).
+TEST(EdgeTest, HasVirtualDestructor)
+{
+  static_assert(std::has_virtual_destructor_v<Edge<int>>,
+                "Edge<E> must have a virtual destructor");
+  static_assert(std::has_virtual_destructor_v<DirectedEdge<int>>,
+                "DirectedEdge<E> must have a virtual destructor");
+  static_assert(std::has_virtual_destructor_v<UndirectedEdge<int>>,
+                "UndirectedEdge<E> must have a virtual destructor");
+
+  // Polymorphic deletion via a base-class pointer must call the
+  // concrete destructor. Pre-fix this was undefined behavior.
+  std::unique_ptr<Edge<int>> e =
+      std::make_unique<DirectedEdge<int>>(VertexId_P{0, 1}, 0, 1.0, 7u);
+  EXPECT_EQ(e->Id(), 7u);
+  // No assertion needed for the destruction itself; it just has to not
+  // be UB. Sanitizers in CI flag any leak.
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch adds `public: virtual ~Edge() = default;` to `Edge<E>`.

`Edge<E>` already had pure virtual member functions (`From`, `To`) but the destructor was the implicit non-virtual one. Polymorphic deletion via a base `Edge<E>*` (e.g. `std::unique_ptr<Edge<E>>`) was undefined behavior, and the class flagged C++ Core Guideline C.35 / clang-tidy [cppcoreguidelines-virtual-class-destructor](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/virtual-class-destructor.html).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
