### PR TITLE
Use target_link_libraries for swig

### DIFF
--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -56,7 +56,7 @@ if (RUBY_FOUND)
   )
   target_include_directories(${SWIG_RB_LIB} SYSTEM PUBLIC ${RUBY_INCLUDE_DIRS})
 
-  SWIG_LINK_LIBRARIES(${SWIG_RB_LIB}
+  target_link_libraries(${SWIG_RB_LIB}
     ${RUBY_LIBRARY}
     gz-utils::gz-utils
     gz-math


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1485, fixes cmake warning with swig

## Summary

`SWIG_LINK_LIBRARIES` has been [deprecated since cmake 3.13](https://cmake.org/cmake/help/latest/module/UseSWIG.html) and it is recommended to use `target_link_libraries` instead. It shows up in 26.04 CI on Jenkins:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_math-ci-main-resolute-amd64&build=3)](https://build.osrfoundation.org/job/gz_math-ci-main-resolute-amd64/3/) https://build.osrfoundation.org/job/gz_math-ci-main-resolute-amd64/3/cmake/


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
