### PR TITLE
graph: Cache vertices and edges

### DIFF
--- a/include/gz/math/graph/Graph.hh
+++ b/include/gz/math/graph/Graph.hh
@@ -182,19 +182,20 @@ namespace graph
       // Update the map of names.
       this->names.insert(std::make_pair(_name, id));
 
+      // Maintain the cached Vertices() view.
+      this->verticesRefCache.emplace(id, std::cref(ret.first->second));
+
       return ret.first->second;
     }
 
     /// \brief The collection of all vertices in the graph.
     /// \return A map of vertices, where keys are Ids and values are
-    /// references to the vertices.
-    public: const VertexRef_M<V> Vertices() const
+    /// references to the vertices. The returned map is a cached view
+    /// owned by the Graph; the reference is valid until the next call
+    /// that adds or removes a vertex.
+    public: const VertexRef_M<V> &Vertices() const
     {
-      VertexRef_M<V> res;
-      for (auto const &v : this->vertices)
-        res.emplace(std::make_pair(v.first, std::cref(v.second)));
-
-      return res;
+      return this->verticesRefCache;
     }
 
     /// \brief The collection of all vertices in the graph with name == _name.
@@ -267,22 +268,21 @@ namespace graph
 
       auto ret = this->edges.insert(std::make_pair(_edge.Id(), _edge));
 
+      // Maintain the cached Edges() view.
+      this->edgesRefCache.emplace(_edge.Id(), std::cref(ret.first->second));
+
       // Return the new edge.
       return ret.first->second;
     }
 
     /// \brief The collection of all edges in the graph.
     /// \return A map of edges, where keys are Ids and values are references
-    /// to the edges.
-    public: const EdgeRef_M<EdgeType> Edges() const
+    /// to the edges. The returned map is a cached view owned by the
+    /// Graph; the reference is valid until the next call that adds or
+    /// removes an edge.
+    public: const EdgeRef_M<EdgeType> &Edges() const
     {
-      EdgeRef_M<EdgeType> res;
-      for (auto const &edge : this->edges)
-      {
-        res.emplace(std::make_pair(edge.first, std::cref(edge.second)));
-      }
-
-      return res;
+      return this->edgesRefCache;
     }
 
     /// \brief Get all vertices that are directly connected with one edge
@@ -535,6 +535,9 @@ namespace graph
       // Remove the vertex.
       this->vertices.erase(_vertex);
 
+      // Maintain the cached Vertices() view.
+      this->verticesRefCache.erase(_vertex);
+
       // Get an iterator to all vertices sharing name.
       auto iterPair = this->names.equal_range(name);
       for (auto it = iterPair.first; it != iterPair.second; ++it)
@@ -605,6 +608,9 @@ namespace graph
       }
 
       this->edges.erase(_edge);
+
+      // Maintain the cached Edges() view.
+      this->edgesRefCache.erase(_edge);
 
       return true;
     }
@@ -756,6 +762,16 @@ namespace graph
 
     /// \brief The set of edges.
     private: std::map<EdgeId, EdgeType> edges;
+
+    /// \brief Cached view of `vertices` as a map of const-references,
+    /// returned by `Vertices()` without rebuilding it on every call.
+    /// Maintained alongside `vertices` in `AddVertex` / `RemoveVertex`.
+    private: VertexRef_M<V> verticesRefCache;
+
+    /// \brief Cached view of `edges` as a map of const-references,
+    /// returned by `Edges()` without rebuilding it on every call.
+    /// Maintained alongside `edges` in `LinkEdge` / `RemoveEdge`.
+    private: EdgeRef_M<EdgeType> edgesRefCache;
 
     /// \brief The adjacency list.
     /// A map where the keys are vertex Ids. For each vertex (v)

--- a/src/graph/Graph_TEST.cc
+++ b/src/graph/Graph_TEST.cc
@@ -459,6 +459,66 @@ TYPED_TEST(GraphTestFixture, EdgelessOutDegree)
 }
 
 /////////////////////////////////////////////////
+// LinkEdge is the public entry point that AddEdge delegates to. It
+// accepts a caller-built edge object (id supplied by the caller),
+// validates both endpoints exist, and inserts the edge into the
+// graph (updating adjacency and the cached Edges() view). Exercised
+// here for both directed and undirected graphs; AddEdge tests only
+// cover the indirect path.
+template <typename GraphT, typename EdgeT>
+void LinkEdgeCoverage()
+{
+  GraphT graph;
+  graph.AddVertex("0", 0, 0);
+  graph.AddVertex("1", 1, 1);
+  // Vertex id 2 is intentionally absent so we can exercise the
+  // missing-endpoint branches.
+
+  // Happy path: both endpoints exist.
+  auto &linked = graph.LinkEdge(EdgeT({0, 1}, 7.5, 1.0, 100));
+  EXPECT_TRUE(linked.Valid());
+  EXPECT_EQ(100u, linked.Id());
+  EXPECT_DOUBLE_EQ(7.5, linked.Data());
+
+  // The cached Edges() view must reflect the newly linked edge.
+  const auto &edges = graph.Edges();
+  ASSERT_EQ(1u, edges.size());
+  EXPECT_EQ(linked.Id(), edges.begin()->first);
+
+  // EdgeFromId and adjacency must agree with the cache.
+  EXPECT_EQ(linked.Id(), graph.EdgeFromId(linked.Id()).Id());
+  EXPECT_EQ(1u, graph.IncidentsFrom(0).size());
+  EXPECT_EQ(1u, graph.IncidentsTo(1).size());
+
+  // Both endpoints missing: returns NullEdge, cache unchanged.
+  auto &missingBoth = graph.LinkEdge(EdgeT({42, 43}, 0.0, 1.0, 101));
+  EXPECT_FALSE(missingBoth.Valid());
+  EXPECT_EQ(1u, graph.Edges().size());
+
+  // Source endpoint missing: returns NullEdge, cache unchanged.
+  auto &missingSrc = graph.LinkEdge(EdgeT({42, 1}, 0.0, 1.0, 102));
+  EXPECT_FALSE(missingSrc.Valid());
+  EXPECT_EQ(1u, graph.Edges().size());
+
+  // Destination endpoint missing: returns NullEdge, cache unchanged.
+  auto &missingDst = graph.LinkEdge(EdgeT({0, 42}, 0.0, 1.0, 103));
+  EXPECT_FALSE(missingDst.Valid());
+  EXPECT_EQ(1u, graph.Edges().size());
+}
+
+/////////////////////////////////////////////////
+TEST(GraphTest, LinkEdgeDirected)
+{
+  LinkEdgeCoverage<DirectedGraph<int, double>, DirectedEdge<double>>();
+}
+
+/////////////////////////////////////////////////
+TEST(GraphTest, LinkEdgeUndirected)
+{
+  LinkEdgeCoverage<UndirectedGraph<int, double>, UndirectedEdge<double>>();
+}
+
+/////////////////////////////////////////////////
 // Regression: renaming a graph-owned vertex via Vertex::SetName and
 // then removing it via Graph::RemoveVertices(name) must find the
 // vertex under its new name. Pre-fix, RemoveVertices read from an

--- a/src/graph/Graph_TEST.cc
+++ b/src/graph/Graph_TEST.cc
@@ -519,6 +519,65 @@ TEST(GraphTest, LinkEdgeUndirected)
 }
 
 /////////////////////////////////////////////////
+// The cached Vertices() and Edges() views must stay consistent with
+// the graph after removals. RemoveEdge must drop the edge from the
+// Edges() cache; RemoveVertex must drop the vertex from the
+// Vertices() cache and cascade to remove its incident edges from the
+// Edges() cache; RemoveVertices(name) must do the same in bulk.
+TYPED_TEST(GraphTestFixture, RemoveKeepsCachedAccessorsConsistent)
+{
+  // 0 -- 1 -- 2, plus a third vertex "1" sharing a name with vertex 1.
+  TypeParam graph(
+  {
+    {{"0", 0, 0}, {"1", 1, 1}, {"2", 2, 2}, {"1", 3, 3}},
+    {{{0, 1}, 0.0}, {{1, 2}, 0.0}}
+  });
+
+  // Sanity check the initial cached state.
+  ASSERT_EQ(4u, graph.Vertices().size());
+  ASSERT_EQ(2u, graph.Edges().size());
+
+  const auto edge01Id = graph.EdgeFromVertices(0, 1).Id();
+  const auto edge12Id = graph.EdgeFromVertices(1, 2).Id();
+  ASSERT_NE(kNullId, edge01Id);
+  ASSERT_NE(kNullId, edge12Id);
+
+  // Removing an edge must update the cached Edges() view, leaving the
+  // Vertices() cache untouched.
+  EXPECT_TRUE(graph.RemoveEdge(edge01Id));
+  {
+    const auto &edges = graph.Edges();
+    EXPECT_EQ(1u, edges.size());
+    EXPECT_EQ(edges.end(), edges.find(edge01Id));
+    EXPECT_NE(edges.end(), edges.find(edge12Id));
+  }
+  EXPECT_EQ(4u, graph.Vertices().size());
+
+  // Removing a vertex must update the cached Vertices() view and
+  // cascade to drop its incident edges from the Edges() cache.
+  EXPECT_TRUE(graph.RemoveVertex(1));
+  {
+    const auto &vertices = graph.Vertices();
+    EXPECT_EQ(3u, vertices.size());
+    EXPECT_EQ(vertices.end(), vertices.find(1));
+    EXPECT_NE(vertices.end(), vertices.find(0));
+    EXPECT_NE(vertices.end(), vertices.find(2));
+    EXPECT_NE(vertices.end(), vertices.find(3));
+  }
+  // The incident edge (1 -- 2) must be gone from the Edges() cache.
+  EXPECT_TRUE(graph.Edges().empty());
+
+  // RemoveVertices(name) must also keep the Vertices() cache in sync.
+  // Only vertex 3 still carries the name "1" at this point.
+  EXPECT_EQ(1u, graph.RemoveVertices("1"));
+  {
+    const auto &vertices = graph.Vertices();
+    EXPECT_EQ(2u, vertices.size());
+    EXPECT_EQ(vertices.end(), vertices.find(3));
+  }
+}
+
+/////////////////////////////////////////////////
 // Regression: renaming a graph-owned vertex via Vertex::SetName and
 // then removing it via Graph::RemoveVertices(name) must find the
 // vertex under its new name. Pre-fix, RemoveVertices read from an


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch caches the result of `Graph::Vertices()` and `Graph::Edges()` instead of rebuilding it on every call. 

The [gz-profiling-flamegraphs 2026-04-21 report](https://caguero.github.io/gz-profiling/) flagged `Graph::Vertices()` as in the `3k_shapes_static` runtime flamegraph at 13.5% of total CPU, called from gz-sim's `ProcessRecreateEntitiesRemove` on every simulation step. 

The fix maintains the ref-map view as a private member kept in sync with the source map: insert in `AddVertex` / `LinkEdge`, erase in `RemoveVertex` / `RemoveEdge`. The accessors become O(1).

Strictly speaking, the cache adds a bit of overhead during adding/removing operations but with just a few calls to `Vertices()`, the overhead is worth it.

### Benchmarks

| Benchmark | main | this PR | Speedup |
|---|---:|---:|---:|
| `BM_AccessorVertices/10000`          |   413 766 ns | 0.093 ns | accessor folded away by compiler |
| `BM_AccessorEdges/10000`             | 1 664 814 ns | 0.093 ns | accessor folded away by compiler |
| `BM_AccessorVerticesIterateAndSum/100`   |   2 351 ns |   191 ns | **12×** |
| `BM_AccessorVerticesIterateAndSum/1000`  |  33 370 ns | 3 451 ns | **10×** |
| `BM_AccessorVerticesIterateAndSum/10000` | 453 309 ns | 51 147 ns | **9×** |

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
