### PR TITLE
ruby: Suppress GCC warnings on SWIG-generated wrappers

### DIFF
--- a/src/ruby/CMakeLists.txt
+++ b/src/ruby/CMakeLists.txt
@@ -48,12 +48,16 @@ if (RUBY_FOUND)
   set(CMAKE_SWIG_OUTDIR "${CMAKE_BINARY_DIR}/lib/ruby")
   SWIG_ADD_LIBRARY(${SWIG_RB_LIB} LANGUAGE ruby SOURCES ruby.i ${swig_i_files})
 
-  # Suppress warnings on SWIG-generated files
+  # Suppress warnings on SWIG-generated files.
   target_compile_options(${SWIG_RB_LIB} PRIVATE
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-pedantic -Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-pedantic -Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter -Wno-switch-default>
     $<$<CXX_COMPILER_ID:Clang>:-Wno-shadow -Wno-unused-parameter -Wno-deprecated-declarations>
     $<$<CXX_COMPILER_ID:AppleClang>:-Wno-shadow -Wno-maybe-uninitialized -Wno-unused-parameter>
   )
+
+  # Skip Ruby's <cstdbool> shim (deprecated in C++17, warns on GCC 15+).
+  target_compile_definitions(${SWIG_RB_LIB} PRIVATE
+    __bool_true_false_are_defined)
   target_include_directories(${SWIG_RB_LIB} SYSTEM PUBLIC ${RUBY_INCLUDE_DIRS})
 
   target_link_libraries(${SWIG_RB_LIB} PRIVATE


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch fixes some remaining Ubuntu Resolute (GCC 15)  [compilation warnings](https://build.osrfoundation.org/job/gz_math-ci-main-resolute-amd64/4/) in the SWIG-built Ruby wrappers.

The nine -Sswitch-default warnings are suppressed, as I don't think we can fix the generated code.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.