### PR TITLE
Add copy/move constructor and assignment operator to Graph class

### DIFF
--- a/include/gz/math/graph/Graph.hh
+++ b/include/gz/math/graph/Graph.hh
@@ -111,6 +111,25 @@ namespace graph
     /// \brief Default constructor.
     public: Graph() = default;
 
+    /// \brief Copy constructor.
+    /// \param[in] _from Graph to copy.
+    public: Graph(const Graph &_from)
+    {
+      this->CopyFrom(_from);
+    }
+
+    /// \brief Copy assignment operator.
+    /// \param[in] _from Graph to copy.
+    /// \return Reference to this graph.
+    public: Graph &operator=(const Graph &_from)
+    {
+      if (this != &_from)
+      {
+        this->CopyFrom(_from);
+      }
+      return *this;
+    }
+
     /// \brief Constructor.
     /// \param[in] _vertices Collection of vertices.
     /// \param[in] _edges Collection of edges.
@@ -761,6 +780,30 @@ namespace graph
     /// the edges (e) with Id (eId) represents a connected path from (v) to
     /// another vertex via (e).
     private: std::map<VertexId, EdgeId_S> adjList;
+
+    /// \brief Copy implementation.
+    /// \param[in] _from Graph to copy.
+    private: void CopyFrom(const Graph &_from)
+    {
+      this->nextVertexId = _from.nextVertexId;
+      this->nextEdgeId = _from.nextEdgeId;
+      this->vertices = _from.vertices;
+      this->edges = _from.edges;
+      this->adjList = _from.adjList;
+
+      // Rebuild caches
+      this->verticesRefCache.clear();
+      for (const auto &[id, vertex] : this->vertices)
+      {
+        this->verticesRefCache.emplace(id, std::cref(vertex));
+      }
+
+      this->edgesRefCache.clear();
+      for (const auto &[id, edge] : this->edges)
+      {
+        this->edgesRefCache.emplace(id, std::cref(edge));
+      }
+    }
   };
 
   /////////////////////////////////////////////////

--- a/include/gz/math/graph/Graph.hh
+++ b/include/gz/math/graph/Graph.hh
@@ -130,6 +130,25 @@ namespace graph
       return *this;
     }
 
+    /// \brief Move constructor.
+    /// \param[in] _from Graph to move.
+    public: Graph(Graph &&_from) noexcept
+    {
+      this->MoveFrom(std::move(_from));
+    }
+
+    /// \brief Move assignment operator.
+    /// \param[in] _from Graph to move.
+    /// \return Reference to this graph.
+    public: Graph &operator=(Graph &&_from) noexcept
+    {
+      if (this != &_from)
+      {
+        this->MoveFrom(std::move(_from));
+      }
+      return *this;
+    }
+
     /// \brief Constructor.
     /// \param[in] _vertices Collection of vertices.
     /// \param[in] _edges Collection of edges.
@@ -803,6 +822,22 @@ namespace graph
       {
         this->edgesRefCache.emplace(id, std::cref(edge));
       }
+    }
+
+    /// \brief Move implementation.
+    /// \param[in] _from Graph to move.
+    private: void MoveFrom(Graph &&_from) noexcept
+    {
+      this->nextVertexId = _from.nextVertexId;
+      this->nextEdgeId = _from.nextEdgeId;
+      this->vertices = std::move(_from.vertices);
+      this->edges = std::move(_from.edges);
+      this->verticesRefCache = std::move(_from.verticesRefCache);
+      this->edgesRefCache = std::move(_from.edgesRefCache);
+      this->adjList = std::move(_from.adjList);
+
+      _from.nextVertexId = 0u;
+      _from.nextEdgeId = 0u;
     }
   };
 

--- a/src/graph/Graph_TEST.cc
+++ b/src/graph/Graph_TEST.cc
@@ -633,3 +633,90 @@ TYPED_TEST(GraphTestFixture, CopyConstructor)
   EXPECT_EQ(0, verticesCopy.at(0).get().Data());
   EXPECT_EQ("0", verticesCopy.at(0).get().Name());
 }
+
+/////////////////////////////////////////////////
+TYPED_TEST(GraphTestFixture, CopyAssignment)
+{
+  TypeParam graph;
+  graph.AddVertex("0", 0, 0);
+  graph.AddVertex("1", 1, 1);
+  graph.AddEdge({0, 1}, 2.0);
+
+  TypeParam graphCopy;
+  graphCopy = graph;
+
+  // Verify vertices in copy
+  auto vertices = graphCopy.Vertices();
+  ASSERT_EQ(2u, vertices.size());
+  EXPECT_NE(vertices.end(), vertices.find(0));
+  EXPECT_NE(vertices.end(), vertices.find(1));
+
+  // Verify edges in copy
+  auto edges = graphCopy.Edges();
+  ASSERT_EQ(1u, edges.size());
+
+  // Modify the original graph
+  graph.VertexFromId(0).Data() = 99;
+  graph.RemoveVertex(0);
+
+  // The copy must remain unaffected
+  auto verticesCopy = graphCopy.Vertices();
+  ASSERT_EQ(2u, verticesCopy.size());
+  ASSERT_NE(verticesCopy.end(), verticesCopy.find(0));
+  EXPECT_EQ(0, verticesCopy.at(0).get().Data());
+  EXPECT_EQ("0", verticesCopy.at(0).get().Name());
+}
+
+/////////////////////////////////////////////////
+TYPED_TEST(GraphTestFixture, MoveConstructor)
+{
+  TypeParam graph;
+  graph.AddVertex("0", 0, 0);
+  graph.AddVertex("1", 1, 1);
+  graph.AddEdge({0, 1}, 2.0);
+
+  // Move the graph
+  TypeParam graphMoved = std::move(graph);
+
+  // Verify vertices in moved graph
+  auto vertices = graphMoved.Vertices();
+  ASSERT_EQ(2u, vertices.size());
+  EXPECT_NE(vertices.end(), vertices.find(0));
+  EXPECT_NE(vertices.end(), vertices.find(1));
+
+  // Verify edges in moved graph
+  auto edges = graphMoved.Edges();
+  ASSERT_EQ(1u, edges.size());
+
+  // Original graph must be empty
+  EXPECT_TRUE(graph.Empty());
+  EXPECT_EQ(0u, graph.Vertices().size());
+  EXPECT_EQ(0u, graph.Edges().size());
+}
+
+/////////////////////////////////////////////////
+TYPED_TEST(GraphTestFixture, MoveAssignment)
+{
+  TypeParam graph;
+  graph.AddVertex("0", 0, 0);
+  graph.AddVertex("1", 1, 1);
+  graph.AddEdge({0, 1}, 2.0);
+
+  TypeParam graphMoved;
+  graphMoved = std::move(graph);
+
+  // Verify vertices in moved graph
+  auto vertices = graphMoved.Vertices();
+  ASSERT_EQ(2u, vertices.size());
+  EXPECT_NE(vertices.end(), vertices.find(0));
+  EXPECT_NE(vertices.end(), vertices.find(1));
+
+  // Verify edges in moved graph
+  auto edges = graphMoved.Edges();
+  ASSERT_EQ(1u, edges.size());
+
+  // Original graph must be empty
+  EXPECT_TRUE(graph.Empty());
+  EXPECT_EQ(0u, graph.Vertices().size());
+  EXPECT_EQ(0u, graph.Edges().size());
+}

--- a/src/graph/Graph_TEST.cc
+++ b/src/graph/Graph_TEST.cc
@@ -600,3 +600,36 @@ TEST(GraphTest, RemoveVerticesAfterSetNameWorks)
   // Bob is untouched.
   EXPECT_TRUE(graph.VertexFromId(1).Valid());
 }
+
+/////////////////////////////////////////////////
+TYPED_TEST(GraphTestFixture, CopyConstructor)
+{
+  TypeParam graph;
+  graph.AddVertex("0", 0, 0);
+  graph.AddVertex("1", 1, 1);
+  graph.AddEdge({0, 1}, 2.0);
+
+  // Copy the graph
+  TypeParam graphCopy = graph;
+
+  // Verify vertices in copy
+  auto vertices = graphCopy.Vertices();
+  ASSERT_EQ(2u, vertices.size());
+  EXPECT_NE(vertices.end(), vertices.find(0));
+  EXPECT_NE(vertices.end(), vertices.find(1));
+
+  // Verify edges in copy
+  auto edges = graphCopy.Edges();
+  ASSERT_EQ(1u, edges.size());
+
+  // Modify the original graph: change vertex data and remove it
+  graph.VertexFromId(0).Data() = 99;
+  graph.RemoveVertex(0);
+
+  // The copy must remain unaffected
+  auto verticesCopy = graphCopy.Vertices();
+  ASSERT_EQ(2u, verticesCopy.size());
+  ASSERT_NE(verticesCopy.end(), verticesCopy.find(0));
+  EXPECT_EQ(0, verticesCopy.at(0).get().Data());
+  EXPECT_EQ("0", verticesCopy.at(0).get().Name());
+}


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/3645

## Summary

Implemented a custom copy constructor and copy assignment operator for the Graph class. The `CopyFrom` helper function copies the graph structure and then rebuilds the cached reference maps so they point correctly to the newly copied internal vertices and edges.

I think recently test failure seen in https://github.com/gazebosim/gz-sim/issues/3645 was caused by https://github.com/gazebosim/gz-math/pull/771. In [EntityComponentManager::ResetTo](https://github.com/gazebosim/gz-sim/blob/63b0440eef47a6c605cde469b0204fd9747dde3c/src/EntityComponentManager.cc#L2345) (used during rewind), a copy of the ECM is made to a local `tmpCopy`, modified, and then copied back to the active ECM.
After `ResetTo` returned, `tmpCopy` went out of scope and was destroyed, leaving the active ECM's graph cache with dangling references pointing to the destroyed vertices.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini 3

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
