### PR TITLE
[bazel] Fix Cone_TEST

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -243,6 +243,15 @@ cc_library(
 )
 
 cc_library(
+    name = "WetVolume",
+    hdrs = ["include/gz/math/detail/WetVolume.hh"],
+    includes = ["include"],
+    deps = [
+        ":Config",
+    ],
+)
+
+cc_library(
     name = "Cone",
     hdrs = [
         "include/gz/math/Cone.hh",
@@ -253,6 +262,7 @@ cc_library(
         ":MassMatrix3",
         ":Material",
         ":Quaternion",
+	":WetVolume",
     ],
 )
 
@@ -267,6 +277,7 @@ cc_library(
         ":MassMatrix3",
         ":Material",
         ":Quaternion",
+	":WetVolume",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -262,7 +262,7 @@ cc_library(
         ":MassMatrix3",
         ":Material",
         ":Quaternion",
-	":WetVolume",
+        ":WetVolume",
     ],
 )
 
@@ -277,7 +277,7 @@ cc_library(
         ":MassMatrix3",
         ":Material",
         ":Quaternion",
-	":WetVolume",
+        ":WetVolume",
     ],
 )
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes the following build error:
```
include/gz/math/detail/Cone.hh:27:10: fatal error: 'gz/math/detail/WetVolume.hh' file not found
```

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
