### PR TITLE
Add Centroid() to the simple shape classes

### DIFF
--- a/include/gz/math/Box.hh
+++ b/include/gz/math/Box.hh
@@ -45,6 +45,12 @@ namespace gz::math
   ///
   /// By default, a box's size (length, width, and height)  is zero.
   ///
+  /// A reference frame is defined with an origin at the geometric center
+  /// of the box, with XYZ coordinate axes perpendicular to each face. The
+  /// XYZ components of the size vector are the dimensions of the box
+  /// parallel to the corresponding coordinate axes. This frame is
+  /// consistent with the SDFormat box shape.
+  ///
   /// See AxisAlignedBox for an axis aligned box implementation.
   template<typename Precision>
   class Box
@@ -155,10 +161,10 @@ namespace gz::math
     public: IntersectionPoints<Precision>
       VerticesBelow(const Plane<Precision> &_plane) const;
 
-    /// \brief Get the centroid of the box in its reference
-    /// frame: the geometric centre: the origin.
-    /// \return The centroid, expressed in the box's
-    /// reference frame.
+    /// \brief Get the centroid of the box. It coincides with the
+    /// origin of the reference frame defined in the class description.
+    /// \return The centroid, in the box's reference frame:
+    /// the zero vector.
     public: Vector3<Precision> Centroid() const;
 
     /// \brief Compute the box's density given a mass value. The

--- a/include/gz/math/Box.hh
+++ b/include/gz/math/Box.hh
@@ -155,6 +155,12 @@ namespace gz::math
     public: IntersectionPoints<Precision>
       VerticesBelow(const Plane<Precision> &_plane) const;
 
+    /// \brief Get the centroid of the box in its reference
+    /// frame: the geometric centre: the origin.
+    /// \return The centroid, expressed in the box's
+    /// reference frame.
+    public: Vector3<Precision> Centroid() const;
+
     /// \brief Compute the box's density given a mass value. The
     /// box is assumed to be solid with uniform density. This
     /// function requires the box's size to be set to

--- a/include/gz/math/Capsule.hh
+++ b/include/gz/math/Capsule.hh
@@ -111,6 +111,12 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
+    /// \brief Get the centroid of the capsule in its reference
+    /// frame: the origin.
+    /// \return The centroid, expressed in the capsule's
+    /// reference frame.
+    public: Vector3<Precision> Centroid() const;
+
     /// \brief Compute the capsule's density given a mass value. The
     /// capsule is assumed to be solid with uniform density. This
     /// function requires the capsule's radius and length to be set to

--- a/include/gz/math/Capsule.hh
+++ b/include/gz/math/Capsule.hh
@@ -34,6 +34,12 @@ namespace gz::math
   /// length, and material properties. The shape is equivalent to a cylinder
   /// aligned with the Z-axis and capped with hemispheres. Radius and
   /// length are in meters. See Material for more on material properties.
+  ///
+  /// A reference frame is defined with an origin at the geometric center
+  /// of the capsule, with XYZ coordinate axes defined with the Z axis
+  /// parallel to the axis of symmetry. The length spans the cylindrical
+  /// segment only; the hemispherical caps extend beyond it. This frame is
+  /// consistent with the SDFormat capsule shape.
   /// \tparam Precision Scalar numeric type.
   template<typename Precision>
   class Capsule
@@ -111,10 +117,10 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
-    /// \brief Get the centroid of the capsule in its reference
-    /// frame: the origin.
-    /// \return The centroid, expressed in the capsule's
-    /// reference frame.
+    /// \brief Get the centroid of the capsule. It coincides with the
+    /// origin of the reference frame defined in the class description.
+    /// \return The centroid, in the capsule's reference frame:
+    /// the zero vector.
     public: Vector3<Precision> Centroid() const;
 
     /// \brief Compute the capsule's density given a mass value. The

--- a/include/gz/math/Cone.hh
+++ b/include/gz/math/Cone.hh
@@ -152,6 +152,14 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
+    /// \brief Get the centroid of the cone in its reference
+    /// frame: on the axis, a quarter of the length above the base. This
+    /// is the standard solid cone centroid; see for example the centroid
+    /// tables in the CRC Standard Mathematical Tables and Formulae.
+    /// \return The centroid, expressed in the cone's
+    /// reference frame.
+    public: Vector3<Precision> Centroid() const;
+
     /// \brief Compute the cone's density given a mass value. The
     /// cone is assumed to be solid with uniform density. This
     /// function requires the cone's radius and length to be set to

--- a/include/gz/math/Cone.hh
+++ b/include/gz/math/Cone.hh
@@ -39,9 +39,13 @@ namespace gz::math
   /// The cone class supports defining a cone with a radius,
   /// length, rotational offset, and material properties. Radius and
   /// length are in meters. See Material for more on material properties.
-  /// By default, a cone's length is aligned with the Z axis where the base
-  /// of the cone is proximal to the origin and vertex points in positive Z.
-  /// The rotational offset encodes a rotation from the z axis.
+  ///
+  /// A reference frame is defined with an origin on the axis of symmetry
+  /// equidistant from the vertex and the circular base, with XYZ
+  /// coordinate axes defined with the Z axis parallel to the axis of
+  /// symmetry and pointing toward the vertex of the cone. This frame is
+  /// consistent with the SDFormat cone shape. The rotational offset
+  /// encodes an additional rotation of the cone relative to this frame.
   template<typename Precision>
   class Cone
   {
@@ -153,9 +157,11 @@ namespace gz::math
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
     /// \brief Get the centroid of the cone in its reference
-    /// frame: on the axis, a quarter of the length above the base. This
-    /// is the standard solid cone centroid; see for example the centroid
-    /// tables in the CRC Standard Mathematical Tables and Formulae.
+    /// frame (defined in the class description): on the axis of symmetry,
+    /// a quarter of the length from the base toward the vertex, i.e.
+    /// (0, 0, -length/4) rotated by the rotational offset. This is the
+    /// standard solid cone centroid; see for example the centroid tables
+    /// in the CRC Standard Mathematical Tables and Formulae.
     /// \return The centroid, expressed in the cone's
     /// reference frame.
     public: Vector3<Precision> Centroid() const;

--- a/include/gz/math/Cylinder.hh
+++ b/include/gz/math/Cylinder.hh
@@ -34,8 +34,11 @@ namespace gz::math
   /// The cylinder class supports defining a cylinder with a radius,
   /// length, rotational offset, and material properties. Radius and
   /// length are in meters. See Material for more on material properties.
-  /// By default, a cylinder's length is aligned with the Z axis. The
-  /// rotational offset encodes a rotation from the z axis.
+  /// A reference frame is defined with an origin at the geometric center
+  /// of the cylinder, with XYZ coordinate axes defined with the Z axis
+  /// parallel to the axis of symmetry. This frame is consistent with the
+  /// SDFormat cylinder shape. The rotational offset encodes an additional
+  /// rotation of the cylinder relative to this frame.
   template<typename Precision>
   class Cylinder
   {
@@ -145,10 +148,10 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
-    /// \brief Get the centroid of the cylinder in its reference
-    /// frame: the origin.
-    /// \return The centroid, expressed in the cylinder's
-    /// reference frame.
+    /// \brief Get the centroid of the cylinder. It coincides with the
+    /// origin of the reference frame defined in the class description.
+    /// \return The centroid, in the cylinder's reference frame:
+    /// the zero vector.
     public: Vector3<Precision> Centroid() const;
 
     /// \brief Compute the cylinder's density given a mass value. The

--- a/include/gz/math/Cylinder.hh
+++ b/include/gz/math/Cylinder.hh
@@ -145,6 +145,12 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
+    /// \brief Get the centroid of the cylinder in its reference
+    /// frame: the origin.
+    /// \return The centroid, expressed in the cylinder's
+    /// reference frame.
+    public: Vector3<Precision> Centroid() const;
+
     /// \brief Compute the cylinder's density given a mass value. The
     /// cylinder is assumed to be solid with uniform density. This
     /// function requires the cylinder's radius and length to be set to

--- a/include/gz/math/Ellipsoid.hh
+++ b/include/gz/math/Ellipsoid.hh
@@ -33,6 +33,12 @@ namespace gz::math
   /// The ellipsoid class supports defining a ellipsoid with three radii and
   /// material properties. Radii are in meters. See Material for more on
   /// material properties.
+  ///
+  /// A reference frame is defined with an origin at the geometric center
+  /// of the ellipsoid, with XYZ coordinate axes aligned with the three
+  /// semi axes, so each component of the radii vector is the semi axis
+  /// along the corresponding coordinate axis. This frame is consistent
+  /// with the SDFormat ellipsoid shape.
   /// \tparam Precision Scalar numeric type.
   template<typename Precision>
   class Ellipsoid
@@ -100,10 +106,10 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
-    /// \brief Get the centroid of the ellipsoid in its reference
-    /// frame: the origin.
-    /// \return The centroid, expressed in the ellipsoid's
-    /// reference frame.
+    /// \brief Get the centroid of the ellipsoid. It coincides with the
+    /// origin of the reference frame defined in the class description.
+    /// \return The centroid, in the ellipsoid's reference frame:
+    /// the zero vector.
     public: Vector3<Precision> Centroid() const;
 
     /// \brief Compute the ellipsoid's density given a mass value. The

--- a/include/gz/math/Ellipsoid.hh
+++ b/include/gz/math/Ellipsoid.hh
@@ -100,6 +100,12 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
+    /// \brief Get the centroid of the ellipsoid in its reference
+    /// frame: the origin.
+    /// \return The centroid, expressed in the ellipsoid's
+    /// reference frame.
+    public: Vector3<Precision> Centroid() const;
+
     /// \brief Compute the ellipsoid's density given a mass value. The
     /// ellipsoid is assumed to be solid with uniform density. This
     /// function requires the ellipsoid's radius and length to be set to

--- a/include/gz/math/Sphere.hh
+++ b/include/gz/math/Sphere.hh
@@ -109,6 +109,12 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
+    /// \brief Get the centroid of the sphere in its reference
+    /// frame: the origin.
+    /// \return The centroid, expressed in the sphere's
+    /// reference frame.
+    public: Vector3<Precision> Centroid() const;
+
     /// \brief Compute the sphere's density given a mass value. The
     /// sphere is assumed to be solid with uniform density. This
     /// function requires the sphere's radius to be set to a

--- a/include/gz/math/Sphere.hh
+++ b/include/gz/math/Sphere.hh
@@ -34,6 +34,10 @@ namespace gz::math
   /// The sphere class supports defining a sphere with a radius and
   /// material properties. Radius is in meters.
   /// See Material for more on material properties.
+  ///
+  /// A reference frame is defined with an origin at the geometric center
+  /// of the sphere; by symmetry, the orientation of the coordinate axes is
+  /// immaterial. This frame is consistent with the SDFormat sphere shape.
   template<typename Precision>
   class Sphere
   {
@@ -109,10 +113,10 @@ namespace gz::math
     public: std::optional<Vector3<Precision>>
       CenterOfVolumeBelow(const Plane<Precision> &_plane) const;
 
-    /// \brief Get the centroid of the sphere in its reference
-    /// frame: the origin.
-    /// \return The centroid, expressed in the sphere's
-    /// reference frame.
+    /// \brief Get the centroid of the sphere. It coincides with the
+    /// origin of the reference frame defined in the class description.
+    /// \return The centroid, in the sphere's reference frame:
+    /// the zero vector.
     public: Vector3<Precision> Centroid() const;
 
     /// \brief Compute the sphere's density given a mass value. The

--- a/include/gz/math/detail/Box.hh
+++ b/include/gz/math/detail/Box.hh
@@ -385,6 +385,13 @@ IntersectionPoints<T> Box<T>::VerticesBelow(const Plane<T> &_plane) const
 
 /////////////////////////////////////////////////
 template<typename T>
+Vector3<T> Box<T>::Centroid() const
+{
+  return Vector3<T>::Zero;
+}
+
+/////////////////////////////////////////////////
+template<typename T>
 T Box<T>::DensityFromMass(const T _mass) const
 {
   if (this->size.Min() <= 0|| _mass <= 0)

--- a/include/gz/math/detail/Capsule.hh
+++ b/include/gz/math/detail/Capsule.hh
@@ -308,6 +308,13 @@ bool Capsule<T>::SetDensityFromMass(const T _mass)
   return true;
 }
 
+/////////////////////////////////////////////////
+template<typename T>
+Vector3<T> Capsule<T>::Centroid() const
+{
+  return Vector3<T>::Zero;
+}
+
 //////////////////////////////////////////////////
 template<typename T>
 T Capsule<T>::DensityFromMass(const T _mass) const

--- a/include/gz/math/detail/Cone.hh
+++ b/include/gz/math/detail/Cone.hh
@@ -342,6 +342,14 @@ bool Cone<T>::SetDensityFromMass(const T _mass)
   return newDensity > 0;
 }
 
+/////////////////////////////////////////////////
+template<typename T>
+Vector3<T> Cone<T>::Centroid() const
+{
+  return this->rotOffset.RotateVector(
+      Vector3<T>(0, 0, -this->length / 4));
+}
+
 //////////////////////////////////////////////////
 template<typename T>
 T Cone<T>::DensityFromMass(const T _mass) const

--- a/include/gz/math/detail/Cylinder.hh
+++ b/include/gz/math/detail/Cylinder.hh
@@ -350,6 +350,13 @@ bool Cylinder<T>::SetDensityFromMass(const T _mass)
   return newDensity > 0;
 }
 
+/////////////////////////////////////////////////
+template<typename T>
+Vector3<T> Cylinder<T>::Centroid() const
+{
+  return Vector3<T>::Zero;
+}
+
 //////////////////////////////////////////////////
 template<typename T>
 T Cylinder<T>::DensityFromMass(const T _mass) const

--- a/include/gz/math/detail/Ellipsoid.hh
+++ b/include/gz/math/detail/Ellipsoid.hh
@@ -200,6 +200,13 @@ bool Ellipsoid<T>::SetDensityFromMass(const T _mass)
   return true;
 }
 
+/////////////////////////////////////////////////
+template<typename T>
+Vector3<T> Ellipsoid<T>::Centroid() const
+{
+  return Vector3<T>::Zero;
+}
+
 //////////////////////////////////////////////////
 template<typename T>
 T Ellipsoid<T>::DensityFromMass(const T _mass) const

--- a/include/gz/math/detail/Sphere.hh
+++ b/include/gz/math/detail/Sphere.hh
@@ -175,6 +175,13 @@ bool Sphere<T>::SetDensityFromMass(const T _mass)
   return newDensity > 0;
 }
 
+/////////////////////////////////////////////////
+template<typename T>
+Vector3<T> Sphere<T>::Centroid() const
+{
+  return Vector3<T>::Zero;
+}
+
 //////////////////////////////////////////////////
 template<typename T>
 T Sphere<T>::DensityFromMass(const T _mass) const

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -712,3 +712,16 @@ TEST(BoxTest, Mass)
   EXPECT_EQ(expectedMassMat.DiagonalMoments(), massMatOpt->DiagonalMoments());
   EXPECT_DOUBLE_EQ(expectedMassMat.Mass(), massMatOpt->Mass());
 }
+
+/////////////////////////////////////////////////
+TEST(BoxTest, Centroid)
+{
+  const math::Boxd box(2.0, 3.0, 4.0);
+  EXPECT_EQ(math::Vector3d::Zero, box.Centroid());
+
+  // The centroid is the centre of volume of the whole shape.
+  const math::Planed above(math::Vector3d::UnitZ, 1e6);
+  auto cov = box.CenterOfVolumeBelow(above);
+  ASSERT_TRUE(cov.has_value());
+  EXPECT_EQ(box.Centroid(), cov.value());
+}

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -296,3 +296,15 @@ TEST(CapsuleTest, VolumeBelowFloat)
     EXPECT_TRUE(cov.value().Z() < 0.0f);
   }
 }
+
+/////////////////////////////////////////////////
+TEST(CapsuleTest, Centroid)
+{
+  const math::Capsuled capsule(2.0, 0.5);
+  EXPECT_EQ(math::Vector3d::Zero, capsule.Centroid());
+
+  const math::Planed above(math::Vector3d::UnitZ, 1e6);
+  auto cov = capsule.CenterOfVolumeBelow(above);
+  ASSERT_TRUE(cov.has_value());
+  EXPECT_EQ(capsule.Centroid(), cov.value());
+}

--- a/src/Cone_TEST.cc
+++ b/src/Cone_TEST.cc
@@ -315,3 +315,26 @@ TEST(ConeTest, VolumeBelowFloat)
     EXPECT_NEAR(0.0f, cov.value().Y(), 1e-3f);
   }
 }
+
+/////////////////////////////////////////////////
+TEST(ConeTest, Centroid)
+{
+  // Base at z = -length/2, apex at +length/2: the centroid sits a quarter
+  // of the length above the base, not at the frame origin.
+  const double l = 2.0;
+  const math::Coned cone(l, 0.5);
+  EXPECT_EQ(math::Vector3d(0, 0, -l / 4), cone.Centroid());
+
+  // The centroid is the centre of volume of the whole shape.
+  const math::Planed above(math::Vector3d::UnitZ, 1e6);
+  auto cov = cone.CenterOfVolumeBelow(above);
+  ASSERT_TRUE(cov.has_value());
+  EXPECT_NEAR(cone.Centroid().Z(), cov.value().Z(), 1e-9);
+
+  // A rotational offset rotates the centroid with the shape: pitching the
+  // cone 90 degrees sends the apex to +x and the centroid to -x.
+  const math::Coned pitched(l, 0.5,
+      math::Quaterniond(0, GZ_PI_2, 0));
+  EXPECT_NEAR(-l / 4, pitched.Centroid().X(), 1e-12);
+  EXPECT_NEAR(0.0, pitched.Centroid().Z(), 1e-12);
+}

--- a/src/Cylinder_TEST.cc
+++ b/src/Cylinder_TEST.cc
@@ -349,3 +349,15 @@ TEST(CylinderTest, VolumeBelowFloat)
     EXPECT_NEAR(-1.0f, cov.value().Z(), 1e-3f);
   }
 }
+
+/////////////////////////////////////////////////
+TEST(CylinderTest, Centroid)
+{
+  const math::Cylinderd cylinder(2.0, 0.5);
+  EXPECT_EQ(math::Vector3d::Zero, cylinder.Centroid());
+
+  const math::Planed above(math::Vector3d::UnitZ, 1e6);
+  auto cov = cylinder.CenterOfVolumeBelow(above);
+  ASSERT_TRUE(cov.has_value());
+  EXPECT_EQ(cylinder.Centroid(), cov.value());
+}

--- a/src/Ellipsoid_TEST.cc
+++ b/src/Ellipsoid_TEST.cc
@@ -339,3 +339,15 @@ TEST(EllipsoidTest, VolumeBelowFloat)
     EXPECT_NEAR(0.0f, cov.value().Z(), 1e-3f);
   }
 }
+
+/////////////////////////////////////////////////
+TEST(EllipsoidTest, Centroid)
+{
+  const math::Ellipsoidd ellipsoid(math::Vector3d(1.0, 2.0, 3.0));
+  EXPECT_EQ(math::Vector3d::Zero, ellipsoid.Centroid());
+
+  const math::Planed above(math::Vector3d::UnitZ, 1e6);
+  auto cov = ellipsoid.CenterOfVolumeBelow(above);
+  ASSERT_TRUE(cov.has_value());
+  EXPECT_EQ(ellipsoid.Centroid(), cov.value());
+}

--- a/src/Sphere_TEST.cc
+++ b/src/Sphere_TEST.cc
@@ -307,3 +307,15 @@ TEST(SphereTest, VolumeBelowFloat)
     EXPECT_NEAR(0.0f, cov.value().Z(), 1e-3f);
   }
 }
+
+/////////////////////////////////////////////////
+TEST(SphereTest, Centroid)
+{
+  const math::Sphered sphere(1.5);
+  EXPECT_EQ(math::Vector3d::Zero, sphere.Centroid());
+
+  const math::Planed above(math::Vector3d::UnitZ, 1e6);
+  auto cov = sphere.CenterOfVolumeBelow(above);
+  ASSERT_TRUE(cov.has_value());
+  EXPECT_EQ(sphere.Centroid(), cov.value());
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This patch adds `Centroid()` to the six simple shape classes, returning the center of volume in the shape's reference frame.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.