### PR TITLE
bazel: set size = small for all tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -123,6 +123,7 @@ test_sources = glob(
 [
     cc_test(
         name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+        size = "small",
         srcs = [src],
         deps = [
             ":gz-math",
@@ -143,6 +144,7 @@ py_test_sources = glob(
 [
     py_test(
         name = src.replace("/", "_").replace(".py", "_py").replace("src_python_pybind11_test_", ""),
+        size = "small",
         srcs = [
             src,
             "src/python_pybind11/test/numpy_helpers.py",

--- a/eigen3/BUILD.bazel
+++ b/eigen3/BUILD.bazel
@@ -51,6 +51,7 @@ test_sources = glob(
 [
     cc_test(
         name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+        size = "small",
         srcs = [src],
         deps = [
             ":eigen3",


### PR DESCRIPTION
# 🎉 New feature

Updates bazel metadata

## Summary

The bazel `size` attribute specifies the resources required to run a test and its default timeout (see [bazel test encyclopedia](https://bazel.build/reference/test-encyclopedia#role-test-runner)). All gz-math tests finished in less than 20 seconds in the [most recent run](https://github.com/gazebosim/gz-math/actions/runs/32202991994/job/95920524994) that I observed, so I set all to have `size = "small"`, which corresponds to a default timeout of 60 seconds.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Test it

Check that bazel CI passes

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
