### PR TITLE
Reduce StopWatch_TEST.py sleep times

### DIFF
--- a/src/python_pybind11/test/StopWatch_TEST.py
+++ b/src/python_pybind11/test/StopWatch_TEST.py
@@ -34,9 +34,9 @@ class TestBox(unittest.TestCase):
         self.assertEqual(timedelta(0), _time.elapsed_stop_time())
 
         # Wait for some time...
-        time.sleep(1)
+        time.sleep(0.05)
         # Now the elapsed time should be greater than or equal to the time slept.
-        self.assertGreaterEqual(_time.elapsed_run_time() + handleSteadyClock, timedelta(seconds=1))
+        self.assertGreaterEqual(_time.elapsed_run_time() + handleSteadyClock, timedelta(milliseconds=50))
 
         # Stop the timer.
         self.assertTrue(_time.stop())
@@ -45,16 +45,16 @@ class TestBox(unittest.TestCase):
         # The stop time should be greater than the start time.
         self.assertGreater(_time.stop_time(), _time.start_time())
         # The elapsed time should still be greater than the time slept.
-        self.assertGreaterEqual(_time.elapsed_run_time() + handleSteadyClock, timedelta(seconds=1))
+        self.assertGreaterEqual(_time.elapsed_run_time() + handleSteadyClock, timedelta(milliseconds=50))
 
         # Save the elapsed time.
         elapsedTime = _time.elapsed_run_time()
 
         # The timer is now stopped, let's sleep some more.
-        time.sleep(1)
+        time.sleep(0.05)
         # The elapsed stop time should be greater than or equal to the time
         # slept.
-        self.assertGreaterEqual(_time.elapsed_stop_time() + handleSteadyClock, timedelta(seconds=1))
+        self.assertGreaterEqual(_time.elapsed_stop_time() + handleSteadyClock, timedelta(milliseconds=50))
         # The elapsed time should be the same.
         self.assertEqual(elapsedTime, _time.elapsed_run_time())
 
@@ -65,14 +65,14 @@ class TestBox(unittest.TestCase):
         # The timer should be running.
         self.assertTrue(_time.running())
         # Sleep for some time.
-        time.sleep(1)
+        time.sleep(0.05)
         # The elapsed stop time should remain the same
         self.assertEqual(elapsedStopTime, _time.elapsed_stop_time())
         # The elapsed time should be greater than the previous elapsed time.
         self.assertGreater(_time.elapsed_run_time(), elapsedTime)
         # The elapsed time should be greater than or equal to the the previous
         # two sleep times.
-        self.assertGreaterEqual(_time.elapsed_run_time() + handleSteadyClock, timedelta(seconds=2))
+        self.assertGreaterEqual(_time.elapsed_run_time() + handleSteadyClock, timedelta(milliseconds=100))
 
     def test_constructor(self):
         watch = Stopwatch()


### PR DESCRIPTION


# 🦟 Bug fix

Ports #326 to python

## Summary

The sleep durations in Stopwatch_TEST.cc were reduced in #326, but the python test still takes nearly 20 seconds. This updates the python test to match the sleep durations used in c++, reducing the duration to 1 second:

* https://build.osrfoundation.org/job/gz_math-ci-pr_any-homebrew-arm64/230/testReport/gz-math.src.python_pybind11.test.StopWatch_TEST/history/



## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini Next

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
