### PR TITLE
Line3: use T instead of double in APIs

### DIFF
--- a/include/gz/math/Line3.hh
+++ b/include/gz/math/Line3.hh
@@ -48,8 +48,8 @@ namespace gz::math
     /// \param[in] _y1 Y coordinate of the start point.
     /// \param[in] _x2 X coordinate of the end point.
     /// \param[in] _y2 Y coordinate of the end point.
-    public: Line3(const double _x1, const double _y1,
-      const double _x2, const double _y2)
+    public: Line3(const T _x1, const T _y1,
+      const T _x2, const T _y2)
     {
       this->Set(_x1, _y1, _x2, _y2);
     }
@@ -61,9 +61,9 @@ namespace gz::math
     /// \param[in] _x2 X coordinate of the end point.
     /// \param[in] _y2 Y coordinate of the end point.
     /// \param[in] _z2 Z coordinate of the end point.
-    public: Line3(const double _x1, const double _y1,
-      const double _z1, const double _x2,
-      const double _y2, const double _z2)
+    public: Line3(const T _x1, const T _y1,
+      const T _z1, const T _x2,
+      const T _y2, const T _z2)
     {
       this->Set(_x1, _y1, _z1, _x2, _y2, _z2);
     }
@@ -100,14 +100,12 @@ namespace gz::math
     /// \param[in] _y2 Y coordinate of the end point.
     /// \param[in] _z Z coordinate of both points,
     /// by default _z is set to 0.
-    public: void Set(const double _x1, const double _y1,
-      const double _x2, const double _y2,
-      const double _z = 0)
+    public: void Set(const T _x1, const T _y1,
+      const T _x2, const T _y2,
+      const T _z = 0)
     {
-      this->pts[0].Set(
-        static_cast<T>(_x1), static_cast<T>(_y1), static_cast<T>(_z));
-      this->pts[1].Set(
-        static_cast<T>(_x2), static_cast<T>(_y2), static_cast<T>(_z));
+      this->pts[0].Set(_x1, _y1, _z);
+      this->pts[1].Set(_x2, _y2, _z);
     }
 
     /// \brief Set the start and end point of the line segment
@@ -117,14 +115,12 @@ namespace gz::math
     /// \param[in] _x2 X coordinate of the end point.
     /// \param[in] _y2 Y coordinate of the end point.
     /// \param[in] _z2 Z coordinate of the end point.
-    public: void Set(const double _x1, const double _y1,
-      const double _z1, const double _x2,
-      const double _y2, const double _z2)
+    public: void Set(const T _x1, const T _y1,
+      const T _z1, const T _x2,
+      const T _y2, const T _z2)
     {
-      this->pts[0].Set(
-        static_cast<T>(_x1), static_cast<T>(_y1), static_cast<T>(_z1));
-      this->pts[1].Set(
-        static_cast<T>(_x2), static_cast<T>(_y2), static_cast<T>(_z2));
+      this->pts[0].Set(_x1, _y1, _z1);
+      this->pts[1].Set(_x2, _y2, _z2);
     }
 
     /// \brief Get the direction of the line

--- a/src/python_pybind11/src/Line3.hh
+++ b/src/python_pybind11/src/Line3.hh
@@ -60,10 +60,10 @@ void helpDefineMathLine3(py::module &m, const std::string &typestr)
     .def(py::init<const gz::math::Vector3<T>&,
                   const gz::math::Vector3<T>&>(),
          "Constructor")
-    .def(py::init<const double, const double, const double, const double>(),
+    .def(py::init<const T, const T, const T, const T>(),
          "2D Constructor where Z coordinates are 0")
-    .def(py::init<const double, const double, const double, const double,
-                  const double, const double>(),
+    .def(py::init<const T, const T, const T, const T,
+                  const T, const T>(),
          "Constructor")
     .def(py::self != py::self)
     .def(py::self == py::self)
@@ -78,15 +78,15 @@ void helpDefineMathLine3(py::module &m, const std::string &typestr)
          &Class::SetB,
          "Set the end point of the line segment")
     .def("set",
-         py::overload_cast<const double, const double, const double,
-                           const double, const double>(&Class::Set),
+         py::overload_cast<const T, const T, const T,
+                           const T, const T>(&Class::Set),
          py::arg("_x1"), py::arg("_y1"), py::arg("_x2"),
-         py::arg("_y2"), py::arg("_z") = 0,
+         py::arg("_y2"), py::arg("_z") = static_cast<T>(0),
          "Set the start and end point of the line segment, assuming that "
          "both points have the same height.")
     .def("set",
-         py::overload_cast<const double, const double, const double,
-                           const double, const double, const double>(
+         py::overload_cast<const T, const T, const T,
+                           const T, const T, const T>(
                              &Class::Set),
          "Set the start and end point of the line segment")
     .def("direction",


### PR DESCRIPTION
# 🎉 New feature

Similar to #809 

## Summary

I noticed that `Line3` is a templated class but still uses `double` in many API arguments. This updates the Constructor and Set APIs to use `T` more consistently instead of double.

Since these are template APIs, it might be safe to backport, but I'm not sure.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Test it

I don't see any uses of this class outside of gz-math, so verifying that CI passes should be sufficient

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini 3.6 Flash


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
