### PR TITLE
Use bazel CI to repeat tests and identify flakes

### DIFF
--- a/.github/workflows/bazel_repeat_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_flaky_tests.yml
@@ -1,5 +1,8 @@
 name: Bazel repeat flaky tests
 on:
+  push:
+    branches:
+      - 'scpeters/bazel_repeat_tests'
   schedule:
     # GitHub caches are purged after 7 days of inactivity, so
     # running twice a week helps protect the bazel cache

--- a/.github/workflows/bazel_repeat_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_flaky_tests.yml
@@ -1,8 +1,5 @@
 name: Bazel repeat flaky tests
 on:
-  push:
-    branches:
-      - 'scpeters/bazel_repeat_tests'
   schedule:
     # GitHub caches are purged after 7 days of inactivity, so
     # running twice a week helps protect the bazel cache

--- a/.github/workflows/bazel_repeat_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_flaky_tests.yml
@@ -5,12 +5,6 @@ on:
     # running twice a week helps protect the bazel cache
     # Run at 16:00 UTC, Monday and Friday
     - cron: '0 16 * * 1,5'
-  workflow_dispatch:
-    inputs:
-      runs_per_test:
-        default: 10
-        required: false
-        type: string
 
 jobs:
   call-repeat-tests:

--- a/.github/workflows/bazel_repeat_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_flaky_tests.yml
@@ -1,8 +1,10 @@
 name: Bazel repeat flaky tests
 on:
-  push:
-    branches:
-      - 'scpeters/bazel_repeat_tests'
+  schedule:
+    # GitHub caches are purged after 7 days of inactivity, so
+    # running twice a week helps protect the bazel cache
+    # Run at 16:00 UTC, Monday and Friday
+    - cron: '0 16 * * 1,5'
   workflow_dispatch:
     inputs:
       runs_per_test:

--- a/.github/workflows/bazel_repeat_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_flaky_tests.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 16 * * 1,5'
 
 jobs:
-  call-repeat-tests:
+  repeat-flaky-tests:
     uses: ./.github/workflows/bazel_repeat_tests.yml
     with:
       flaky: 1

--- a/.github/workflows/bazel_repeat_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_flaky_tests.yml
@@ -1,0 +1,18 @@
+name: Bazel repeat flaky tests
+on:
+  push:
+    branches:
+      - 'scpeters/bazel_repeat_tests'
+  workflow_dispatch:
+    inputs:
+      runs_per_test:
+        default: 10
+        required: false
+        type: string
+
+jobs:
+  call-repeat-tests:
+    uses: ./.github/workflows/bazel_repeat_tests.yml
+    with:
+      flaky: 1
+      runs_per_test: 10

--- a/.github/workflows/bazel_repeat_non_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_non_flaky_tests.yml
@@ -1,5 +1,8 @@
 name: Bazel repeat non-flaky tests
 on:
+  push:
+    branches:
+      - 'scpeters/bazel_repeat_tests'
   schedule:
     # GitHub caches are purged after 7 days of inactivity, so
     # running twice a week helps protect the bazel cache

--- a/.github/workflows/bazel_repeat_non_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_non_flaky_tests.yml
@@ -1,0 +1,18 @@
+name: Bazel repeat non-flaky tests
+on:
+  push:
+    branches:
+      - 'scpeters/bazel_repeat_tests'
+  workflow_dispatch:
+    inputs:
+      runs_per_test:
+        default: 10
+        required: false
+        type: string
+
+jobs:
+  call-repeat-tests:
+    uses: ./.github/workflows/bazel_repeat_tests.yml
+    with:
+      flaky: 0
+      runs_per_test: 10

--- a/.github/workflows/bazel_repeat_non_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_non_flaky_tests.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 17 * * 1,5'
 
 jobs:
-  call-repeat-tests:
+  repeat-non-flaky-tests:
     uses: ./.github/workflows/bazel_repeat_tests.yml
     with:
       flaky: 0

--- a/.github/workflows/bazel_repeat_non_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_non_flaky_tests.yml
@@ -1,8 +1,10 @@
 name: Bazel repeat non-flaky tests
 on:
-  push:
-    branches:
-      - 'scpeters/bazel_repeat_tests'
+  schedule:
+    # GitHub caches are purged after 7 days of inactivity, so
+    # running twice a week helps protect the bazel cache
+    # Run at 17:00 UTC, Monday and Friday
+    - cron: '0 17 * * 1,5'
   workflow_dispatch:
     inputs:
       runs_per_test:

--- a/.github/workflows/bazel_repeat_non_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_non_flaky_tests.yml
@@ -5,12 +5,6 @@ on:
     # running twice a week helps protect the bazel cache
     # Run at 17:00 UTC, Monday and Friday
     - cron: '0 17 * * 1,5'
-  workflow_dispatch:
-    inputs:
-      runs_per_test:
-        default: 10
-        required: false
-        type: string
 
 jobs:
   call-repeat-tests:

--- a/.github/workflows/bazel_repeat_non_flaky_tests.yml
+++ b/.github/workflows/bazel_repeat_non_flaky_tests.yml
@@ -1,8 +1,5 @@
 name: Bazel repeat non-flaky tests
 on:
-  push:
-    branches:
-      - 'scpeters/bazel_repeat_tests'
   schedule:
     # GitHub caches are purged after 7 days of inactivity, so
     # running twice a week helps protect the bazel cache

--- a/.github/workflows/bazel_repeat_tests.yml
+++ b/.github/workflows/bazel_repeat_tests.yml
@@ -3,10 +3,12 @@ on:
   workflow_call:
     inputs: &shared_inputs
       flaky:
+        description: "0 to execute non-flaky tests, 1 to execute flaky tests"
         default: 0
         required: false
         type: string
       runs_per_test:
+        description: "Number of times to repeat each test"
         default: 10
         required: false
         type: string

--- a/.github/workflows/bazel_repeat_tests.yml
+++ b/.github/workflows/bazel_repeat_tests.yml
@@ -1,0 +1,43 @@
+name: Bazel repeat tests
+on:
+  workflow_call:
+    inputs:
+      flaky:
+        default: 0
+        required: false
+        type: string
+      runs_per_test:
+        default: 10
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      flaky:
+        default: 0
+        required: false
+        type: string
+      runs_per_test:
+        default: 10
+        required: false
+        type: string
+
+jobs:
+  repeat-tests:
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7.7.0
+    with:
+      folders: |
+        [
+          "."
+        ]
+      exclude: |
+        [
+          {"folder": ".", "bzlmodEnabled": false}
+        ]
+      exclude_windows: true
+      bazel_test_command: |
+        # Exit with success code 0 if no targets match the query
+        # `grep -q '^' fails if the query output is empty
+        bazel query "attr(flaky, ${{ inputs.flaky }}, tests(//...))" \
+            | grep -q '^' || exit 0
+        bazel test --runs_per_test=${{ inputs.runs_per_test }} \
+            $(bazel query "attr(flaky, ${{ inputs.flaky }}, tests(//...))")

--- a/.github/workflows/bazel_repeat_tests.yml
+++ b/.github/workflows/bazel_repeat_tests.yml
@@ -1,7 +1,7 @@
 name: Bazel repeat tests
 on:
   workflow_call:
-    inputs:
+    inputs: &shared_inputs
       flaky:
         default: 0
         required: false
@@ -11,15 +11,7 @@ on:
         required: false
         type: string
   workflow_dispatch:
-    inputs:
-      flaky:
-        default: 0
-        required: false
-        type: string
-      runs_per_test:
-        default: 10
-        required: false
-        type: string
+    inputs: *shared_inputs
 
 jobs:
   repeat-tests:

--- a/.github/workflows/bazel_repeat_tests.yml
+++ b/.github/workflows/bazel_repeat_tests.yml
@@ -34,4 +34,5 @@ jobs:
         bazel query "attr(flaky, ${{ inputs.flaky }}, tests(//...))" \
             | grep -q '^' || exit 0
         bazel test --runs_per_test=${{ inputs.runs_per_test }} \
+            --test_output=errors \
             $(bazel query "attr(flaky, ${{ inputs.flaky }}, tests(//...))")


### PR DESCRIPTION
# 🎉 New feature

## Summary

This adds workflows that can run tests repeatedly in bazel to gain information about flaky tests. Since bazel targets can be annotated as flaky (see https://github.com/gazebosim/gz-transport/pull/866 for an example), distinct workflows are created to execute flaky and non-flaky tests separately.

Any failures of "non-flaky" tests indicate that the offending test should be annotated as flaky. The results from repeated executions of flaky tests provides flakiness statistics
and may aid in diagnosing the root cause of flakiness.

The workflows are implemented with a parameterized `Bazel repeat tests` workflow that is invoked via `workflow_call` by the `Bazel repeat flaky tests` and `Bazel repeat non-flaky tests` workflows. For testing, the initial version (https://github.com/gazebosim/gz-math/commit/37f88bf72cc2d2e60f62a7f2a6fa80f8e1d08368) of the flaky and non-flaky workflows are triggered on push to this branch in order to confirm that the workflows run properly, and are adjusted in https://github.com/gazebosim/gz-math/commit/219ca8a755225bbfa7db5291e3f146e391ce44ce to run on a schedule on Mondays and Fridays. I believe GitHub purges unused caches every 7 days, so this frequency prevents the bazel cache from being purged.

Each workflow will be manually invokable via `workflow_dispatch` once this PR is merged, with the `runs_per_test` parameter exposed by each workflow, with a default value of `10`.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

We can backport this if we want, but the scheduled workflows will only run from `main`.

## Test it

Review the CI results from https://github.com/gazebosim/gz-math/pull/820/commits/404492e15a32db159994635d771a7f97effe6222

* [Repeat flaky tests result](https://github.com/gazebosim/gz-math/actions/runs/32538391325) was successful in 46 seconds. There are no tests annotated as flaky in this repo, so it ended quickly
* [Repeat non-flaky tests result](https://github.com/gazebosim/gz-math/actions/runs/32538391322/job/96943484088) was successful in 4m53s, executing all bazel tests 10 times

<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
