### PR TITLE
Fix Plane intersection Python defaults

### DIFF
--- a/src/python_pybind11/src/Plane.hh
+++ b/src/python_pybind11/src/Plane.hh
@@ -78,8 +78,8 @@ void defineMathPlane(py::module &m, const std::string &typestr)
          "Get distance to the plane give an origin and direction.")
     .def("intersection",
          &Class::Intersection,
-         py::arg("_point") = gz::math::Vector3<T>::Zero,
-         py::arg("_gradient") = gz::math::Vector3<T>::Zero,
+         py::arg("_point"),
+         py::arg("_gradient"),
          py::arg("_tolerance") = 1e-6,
          "Get the intersection of an infinite line with the plane, "
          "given the line's gradient and a point in parametrized space.")

--- a/src/python_pybind11/test/Plane_TEST.py
+++ b/src/python_pybind11/test/Plane_TEST.py
@@ -119,6 +119,14 @@ class TestPlane(unittest.TestCase):
 
     def test_intersection(self):
         plane = Planed(Vector3d(0.5, 0, 1), 1)
+
+        # Match the C++ API: point and gradient are required, while tolerance
+        # remains optional.
+        with self.assertRaises(TypeError):
+            plane.intersection()
+        with self.assertRaises(TypeError):
+            plane.intersection(Vector3d())
+
         intersect = plane.intersection(Vector3d(0, 0, 0), Vector3d(1, 0, 1))
         self.assertTrue(intersect is not None)
         self.assertAlmostEqual(intersect.dot(plane.normal()), plane.offset(), 1e-6)


### PR DESCRIPTION
# 🦟 Bug fix

Refs #808.

## Summary

`Plane.intersection()` currently accepts calls without a point or gradient even though the C++ API requires both arguments. This change removes those two Python binding defaults, retains the optional tolerance, and adds regression coverage for zero- and one-argument calls.

Before this change, `plane.intersection()` is accepted. After this change, missing point or gradient arguments raise `TypeError`, while the two-argument call succeeds and `_tolerance` remains optional.

## Backport Policy

- [x] I am not sure

## Testing

- compiled the affected pybind11 binding from current `main` with a focused harness
- verified the baseline accepts `Plane.intersection()` with zero arguments
- verified the patched binding raises `TypeError` for missing point / gradient
- verified the two-argument call succeeds and tolerance remains optional
- `git diff --check`

The full CMake suite was not run locally because the test container does not include the project's CMake dependencies.

## Checklist

- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Considered updating Python bindings
- [ ] `codecheck` passed
- [ ] All tests passed
- [ ] Updated Bazel files (no files added)
- [ ] Reviewed another open pull request
- [x] GenAI was used and the commit includes an `Assisted-by` trailer

Some portions of this pull request were generated using OpenAI Codex (GPT-5.6).

Assisted-by: OpenAI Codex (GPT-5.6)