### PR TITLE
Fix volumeBelow and CenterOfVolumeBelow instability

### DIFF
--- a/include/gz/math/detail/Box.hh
+++ b/include/gz/math/detail/Box.hh
@@ -22,11 +22,31 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <limits>
 #include <optional>
 #include <vector>
 
 namespace gz::math
 {
+namespace detail
+{
+/// \brief Smallest M_i = |n_i| * size_i that the Box inclusion-exclusion
+/// formulas treat as an axis the plane crosses, rather than one it is
+/// parallel to. Differencing F(x) - F(x - M_i) cancels catastrophically as
+/// M_i shrinks, leaving the centre of volume with a relative error near
+/// eps * (Msum / M_i)^2. Dropping the axis instead errs by about
+/// (M_i / Msum)^2, so the cut sits where the two meet, eps^(1/4) * Msum, and
+/// both stay near sqrt(eps).
+/// \param[in] _msum Sum of M_i over the three axes.
+/// \return The threshold. Zero for integer types, which do not round.
+template<typename T>
+T BoxNegligibleSpan(T _msum)
+{
+  return static_cast<T>(_msum *
+      std::sqrt(std::sqrt(std::numeric_limits<T>::epsilon())));
+}
+}  // namespace detail
+
 //////////////////////////////////////////////////
 template<typename T>
 Box<T>::Box(T _length, T _width, T _height)
@@ -159,8 +179,32 @@ T Box<T>::VolumeBelow(const Plane<T> &_plane) const
   if (alpha >= Msum)
     return totalVol;
 
-  // Count how many M_i are > 0
-  int nonzero = (M1 > 0 ? 1 : 0) + (M2 > 0 ? 1 : 0) + (M3 > 0 ? 1 : 0);
+  // Keep the axes whose M_i is not negligible. A negligible one is an axis
+  // the plane is parallel to within rounding: drop it as if M_i were zero,
+  // moving the plane by the mean of its contribution, M_i / 2, which keeps
+  // the volume accurate to second order in M_i. See BoxNegligibleSpan.
+  const T negligible = detail::BoxNegligibleSpan(Msum);
+  std::array<T, 3> Mv{};
+  int nonzero = 0;
+  T alphaKept = alpha;
+  T keptSum = 0;
+  for (const T Mi : {M1, M2, M3})
+  {
+    if (Mi > negligible)
+    {
+      Mv[nonzero++] = Mi;
+      keptSum += Mi;
+    }
+    else
+    {
+      alphaKept -= Mi / 2;
+    }
+  }
+
+  if (alphaKept <= 0)
+    return 0;
+  if (alphaKept >= keptSum)
+    return totalVol;
 
   auto cube = [](T x) -> T { return x * x * x; };
   auto clampPos = [](T x) -> T { return x > 0 ? x : 0; };
@@ -168,43 +212,37 @@ T Box<T>::VolumeBelow(const Plane<T> &_plane) const
   if (nonzero == 3)
   {
     // 3D IE formula
-    T ie3 = cube(alpha)
-      - cube(clampPos(alpha - M1))
-      - cube(clampPos(alpha - M2))
-      - cube(clampPos(alpha - M3))
-      + cube(clampPos(alpha - M1 - M2))
-      + cube(clampPos(alpha - M1 - M3))
-      + cube(clampPos(alpha - M2 - M3))
-      - cube(clampPos(alpha - M1 - M2 - M3));
-    return totalVol * ie3 / (6 * M1 * M2 * M3);
+    T ie3 = cube(alphaKept)
+      - cube(clampPos(alphaKept - Mv[0]))
+      - cube(clampPos(alphaKept - Mv[1]))
+      - cube(clampPos(alphaKept - Mv[2]))
+      + cube(clampPos(alphaKept - Mv[0] - Mv[1]))
+      + cube(clampPos(alphaKept - Mv[0] - Mv[2]))
+      + cube(clampPos(alphaKept - Mv[1] - Mv[2]))
+      - cube(clampPos(alphaKept - Mv[0] - Mv[1] - Mv[2]));
+    return totalVol * ie3 / (6 * Mv[0] * Mv[1] * Mv[2]);
   }
   else if (nonzero == 2)
   {
-    // 2D IE formula — find the two non-zero M values
-    std::array<T, 2> Mv;
-    int idx = 0;
-    if (M1 > 0) Mv[idx++] = M1;
-    if (M2 > 0) Mv[idx++] = M2;
-    if (M3 > 0) Mv[idx++] = M3;
+    // 2D IE formula over the two kept axes
     T Ma = Mv[0], Mb = Mv[1];
     auto square = [](T x) -> T { return x * x; };
-    T ie2 = square(alpha)
-      - square(clampPos(alpha - Ma))
-      - square(clampPos(alpha - Mb))
-      + square(clampPos(alpha - Ma - Mb));
+    T ie2 = square(alphaKept)
+      - square(clampPos(alphaKept - Ma))
+      - square(clampPos(alphaKept - Mb))
+      + square(clampPos(alphaKept - Ma - Mb));
     return totalVol * ie2 / (2 * Ma * Mb);
   }
   else if (nonzero == 1)
   {
     // 1D case
-    T Mk = M1 > 0 ? M1 : (M2 > 0 ? M2 : M3);
-    T frac = alpha / Mk;
+    T frac = alphaKept / Mv[0];
     return totalVol * std::clamp(frac, T(0), T(1));
   }
   else
   {
     // 0D case: degenerate box
-    return alpha >= 0 ? totalVol : 0;
+    return alphaKept >= 0 ? totalVol : 0;
   }
 }
 
@@ -244,7 +282,8 @@ std::optional<Vector3<T>>
 
   auto clampPos = [](T x) -> T { return x > 0 ? x : 0; };
 
-  // F_k(x) = max(0, x)^k / k!
+  // F_k(x) = max(0, x)^k / k!, with F_0 the unit step
+  auto F0 = [](T x) -> T { return x > 0 ? T(1) : T(0); };
   auto F1 = [&clampPos](T x) -> T { return clampPos(x); };
   auto F2 = [&clampPos](T x) -> T {
     T cx = clampPos(x); return cx * cx / 2;
@@ -255,8 +294,9 @@ std::optional<Vector3<T>>
   auto F4 = [&clampPos](T x) -> T {
     T cx = clampPos(x); return cx * cx * cx * cx / 24;
   };
-  auto Fn = [&F1, &F2, &F3, &F4](int _n, T x) -> T {
+  auto Fn = [&F0, &F1, &F2, &F3, &F4](int _n, T x) -> T {
     switch (_n) {
+      case 0: return F0(x);
       case 1: return F1(x);
       case 2: return F2(x);
       case 3: return F3(x);
@@ -269,22 +309,43 @@ std::optional<Vector3<T>>
   const std::array<T, 3> half = {h1, h2, h3};
   const std::array<T, 3> nComp = {n.X(), n.Y(), n.Z()};
 
-  // Identify non-trivial axes (where M_i > 0)
+  // Identify non-trivial axes: those whose M_i is not negligible. A
+  // negligible one is an axis the plane is parallel to within rounding: drop
+  // it as if M_i were zero, moving the plane by the mean of its contribution,
+  // M_i / 2. See BoxNegligibleSpan.
+  const T negligible = detail::BoxNegligibleSpan(Msum);
   std::array<int, 3> ntAxes = {};
   int k = 0;
+  T alphaKept = alpha;
+  T keptSum = 0;
   for (int i = 0; i < 3; ++i)
   {
-    if (M[i] > 0)
+    if (M[i] > negligible)
+    {
       ntAxes[k++] = i;
+      keptSum += M[i];
+    }
+    else
+    {
+      alphaKept -= M[i] / 2;
+    }
   }
 
-  if (k == 0)
-    return alpha >= 0 ? std::optional<Vector3<T>>(Vector3<T>::Zero)
-                      : std::nullopt;
+  if (alphaKept <= 0)
+    return std::nullopt;
 
-  // Compute V_v (volume in v-coordinates, where v_i = M_i * u_i):
+  if (alphaKept >= keptSum)
+    return Vector3<T>::Zero;
+
+  if (k == 0)
+    return alphaKept >= 0 ? std::optional<Vector3<T>>(Vector3<T>::Zero)
+                          : std::nullopt;
+
+  // Compute V_v (volume in v-coordinates, where v_i = M_i * u_i), and its
+  // derivative with respect to alpha, which the dropped axes need:
   // V_v = sum over subsets S of non-trivial axes: (-1)^|S| F_k(alpha - M_S)
   T Vv = 0;
+  T dVv = 0;
   for (int mask = 0; mask < (1 << k); ++mask)
   {
     T Msub = 0;
@@ -298,7 +359,8 @@ std::optional<Vector3<T>>
       }
     }
     T sgn = (bits % 2 == 0) ? T(1) : T(-1);
-    Vv += sgn * Fn(k, alpha - Msub);
+    Vv += sgn * Fn(k, alphaKept - Msub);
+    dVv += sgn * Fn(k - 1, alphaKept - Msub);
   }
 
   if (Vv <= 0)
@@ -339,7 +401,7 @@ std::optional<Vector3<T>>
         }
       }
       T sgn = (bits % 2 == 0) ? T(1) : T(-1);
-      T a = alpha - Msub;
+      T a = alphaKept - Msub;
       Ji += sgn * (Fn(k + 1, a) - Fn(k + 1, a - M[i])
                    - M[i] * Fn(k, a - M[i]));
     }
@@ -348,7 +410,20 @@ std::optional<Vector3<T>>
     T sgn = nComp[i] >= 0 ? T(1) : T(-1);
     result[i] = sgn * half[i] * (2 * zbar - 1);
   }
-  // Trivial axes remain 0 (default Vector3 initialization)
+
+  // Dropped axes with M_i > 0. Averaging over u_i in [0, 1] puts the centroid
+  // at zbar_i = 1/2 - M_i * V_v' / (12 * V_v), with an error of third order
+  // in M_i where V_v is smooth: the region leans toward the low side of the
+  // plane. Axes with M_i == 0 remain 0 (default Vector3 initialization).
+  for (int i = 0; i < 3; ++i)
+  {
+    if (M[i] > negligible || M[i] <= 0)
+      continue;
+
+    T zbar = std::clamp(T(0.5) - M[i] * dVv / (12 * Vv), T(0), T(1));
+    T sgn = nComp[i] >= 0 ? T(1) : T(-1);
+    result[i] = sgn * half[i] * (2 * zbar - 1);
+  }
 
   return result;
 }

--- a/include/gz/math/detail/Box.hh
+++ b/include/gz/math/detail/Box.hh
@@ -26,8 +26,15 @@
 #include <optional>
 #include <vector>
 
+#include <gz/math/config.hh>
+
 namespace gz::math
 {
+// Inside the versioned namespace, like every other gz::math detail helper:
+// Box<T> lives there, so an unqualified detail:: in its members must find
+// this namespace and not a second, unversioned gz::math::detail. MSVC
+// resolves it to the versioned one and fails otherwise.
+inline namespace GZ_MATH_VERSION_NAMESPACE {
 namespace detail
 {
 /// \brief Smallest M_i = |n_i| * size_i that the Box inclusion-exclusion
@@ -46,6 +53,7 @@ T BoxNegligibleSpan(T _msum)
       std::sqrt(std::sqrt(std::numeric_limits<T>::epsilon())));
 }
 }  // namespace detail
+}  // namespace GZ_MATH_VERSION_NAMESPACE
 
 //////////////////////////////////////////////////
 template<typename T>

--- a/src/Box_TEST.cc
+++ b/src/Box_TEST.cc
@@ -17,9 +17,67 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <initializer_list>
+#include <string>
+
 #include "gz/math/Box.hh"
 
 using namespace gz;
+
+/////////////////////////////////////////////////
+/// \brief Check VolumeBelow and CenterOfVolumeBelow of a 1 x 0.15 x 0.15 box
+/// against a plane z = d - tx x - ty y that is nearly parallel to its top
+/// face, as when the box floats level. The plane crosses only the long faces,
+/// so the region below is a prism and has closed forms:
+///   volume = W L depth, with depth = d + H / 2
+///   centre = (-tx L^2 / (12 depth), -ty W^2 / (12 depth),
+///             (d - H / 2) / 2 + (tx^2 L^2 + ty^2 W^2) / (24 depth))
+/// \param[in] _slopes Values of tx to test, each also negated.
+/// \param[in] _volumeTol Relative tolerance on the volume.
+/// \param[in] _centreTol Absolute tolerance on the centre of volume [m].
+template<typename T>
+void CheckNearlyParallelPlane(const std::initializer_list<T> &_slopes,
+    double _volumeTol, double _centreTol)
+{
+  const T length = 1;
+  const T width = T(0.15);
+  const T height = T(0.15);
+  math::Box<T> box(length, width, height);
+
+  for (const T tx : _slopes)
+  {
+    for (const T ty : {T(0), T(1e-12), T(1e-4)})
+    {
+      for (const T d : {T(-0.05), T(0), T(0.035)})
+      {
+        for (const T sign : {T(1), T(-1)})
+        {
+          const double px = sign * tx;
+          const double py = ty;
+          const double depth = d + height / 2.0;
+          const double lengthSq = static_cast<double>(length) * length;
+          const double widthSq = static_cast<double>(width) * width;
+          SCOPED_TRACE("tx " + std::to_string(px) + " ty " +
+              std::to_string(py) + " d " + std::to_string(d));
+
+          math::Plane<T> plane(math::Vector3<T>(sign * tx, ty, 1), d);
+
+          const double volume = static_cast<double>(width) * length * depth;
+          EXPECT_NEAR(volume, box.VolumeBelow(plane), _volumeTol * volume);
+
+          auto centre = box.CenterOfVolumeBelow(plane);
+          ASSERT_TRUE(centre.has_value());
+          EXPECT_NEAR(-px * lengthSq / (12 * depth), centre->X(), _centreTol);
+          EXPECT_NEAR(-py * widthSq / (12 * depth), centre->Y(), _centreTol);
+          EXPECT_NEAR((d - height / 2.0) / 2 +
+              (px * px * lengthSq + py * py * widthSq) / (24 * depth),
+              centre->Z(), _centreTol);
+        }
+      }
+    }
+  }
+}
 
 /////////////////////////////////////////////////
 TEST(BoxTest, Constructor)
@@ -336,6 +394,18 @@ TEST(BoxTest, CenterOfVolumeBelow)
     EXPECT_EQ(box.CenterOfVolumeBelow(plane).value(),
       math::Vector3d(0, 0, 0.5));
   }
+}
+
+//////////////////////////////////////////////////
+TEST(BoxTest, BelowNearlyParallelPlane)
+{
+  // A plane within rounding of parallel to a face made the inclusion-exclusion
+  // sums cancel catastrophically: tilted 1e-12, the centre of volume of this
+  // 1 m box came out 1e6 m away, and two such tilts broke the volume too.
+  CheckNearlyParallelPlane<double>(
+      {0, 1e-15, 1e-12, 1e-9, 1e-7, 1e-5, 1e-4, 1e-3}, 1e-9, 1e-8);
+  CheckNearlyParallelPlane<float>(
+      {0, 1e-9f, 1e-6f, 1e-4f, 1e-3f}, 1e-5, 1e-4);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

  - What was wrong: in include/gz/math/detail/Box.hh, VolumeBelow and CenterOfVolumeBelow use exact formulas that subtract nearly equal numbers. When the plane is almost parallel to a face,
    those subtractions lose all precision. The formulas came in with gazebosim/gz-math#724.
  - What I changed:
    - An axis the plane is parallel to within rounding is now treated like an exactly parallel one, with the plane shifted by that axis's average contribution.
    - The centre along that axis gets an exact first-order correction, which reproduces the physical offset −θL²/(12D), so a tilted hull keeps its small restoring moment.
    - The cutoff scales with the float type's epsilon (about 1e-4 for double, 2e-2 for float). Integer boxes behave exactly as before.
  - Accuracy, measured against exact prism formulas for tilts from 0 to 1e-3, with one or two tiny slopes:

  |               | Volume error (relative) | Centre error                         |
  |---------------|-------------------------|--------------------------------------|
  | Before        | up to 2×10⁹             | up to 6×10¹³ m, some centres missing |
  | After, double | 7×10⁻¹⁴                 | under 6×10⁻¹⁰ m                      |
  | After, float  | 1.5×10⁻⁷                | 1.7×10⁻⁶ m                           |

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Opues 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
